### PR TITLE
feat: refactors bergamo mapper

### DIFF
--- a/examples/bergamo_session.py
+++ b/examples/bergamo_session.py
@@ -4,14 +4,16 @@ from pathlib import Path
 
 from aind_metadata_mapper.bergamo.session import (
     BergamoEtl,
+    JobSettings,
     RawImageInfo,
-    UserSettings,
 )
 
 # Check the UserSettings class for list of defaults that may need to override
 # This example just sets the required fields.
 
-user_settings = UserSettings(
+user_settings = JobSettings(
+    input_source=Path("/directory/of/tiff/files/"),
+    output_directory=Path("/location/to/save/to/"),
     experimenter_full_name=["John Smith"],
     subject_id="12345",
     session_start_time=datetime(2020, 10, 10, 12, 5, 00),
@@ -25,9 +27,7 @@ user_settings = UserSettings(
 )
 
 etl_job = BergamoEtl(
-    input_source=Path("/directory/of/tiff/files/"),
-    output_directory=Path("/location/to/save/to/"),
-    user_settings=user_settings,
+    job_settings=user_settings,
 )
 
 # To crawl through the tiff directory and parse the headers, simply run:
@@ -74,3 +74,14 @@ session = etl_job._transform(raw_image_info)
 
 # Write the session json file to the output directory
 etl_job._load(session)
+
+# We can also instantiate the class using a json string. This will make it
+# easier to run via an rest api
+
+job_settings_json = user_settings.model_dump_json()
+
+etl_job = BergamoEtl(
+    job_settings=job_settings_json,
+)
+
+etl_job.run_job()

--- a/src/aind_metadata_mapper/core.py
+++ b/src/aind_metadata_mapper/core.py
@@ -5,10 +5,121 @@ import logging
 from abc import ABC, abstractmethod
 from os import PathLike
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from aind_data_schema.base import AindCoreModel
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic_settings import BaseSettings
+
+_T = TypeVar("_T", bound=BaseSettings)
+
+
+class JobResponse(BaseModel):
+    """Standard model of a JobResponse."""
+
+    model_config = ConfigDict(extra="forbid")
+    status_code: int
+    message: Optional[str] = Field(None)
+    data: Optional[str] = Field(None)
+
+
+class GenericEtl(ABC, Generic[_T]):
+    """A generic etl class. Child classes will need to create a JobSettings
+    object that is json serializable. Child class will also need to implement
+    the run_job method, which returns a JobResponse object."""
+
+    def __init__(self, job_settings: _T):
+        """
+        Class constructor for the GenericEtl class.
+        Parameters
+        ----------
+        job_settings : _T
+          Generic type that is bound by the BaseSettings class.
+        """
+        self.job_settings = job_settings
+
+    @staticmethod
+    def _run_validation_check(
+        model_instance: AindCoreModel,
+    ) -> Optional[ValidationError]:
+        """
+        Run a validation check on the model_instance.
+        Parameters
+        ----------
+        model_instance : AindCoreModel
+          Model to validate.
+
+        Returns
+        -------
+        Optional[ValidationError]
+          None if no validation errors are detected. Else, returns the
+          ValidationError object.
+
+        """
+        try:
+            model_instance.model_validate(model_instance.__dict__)
+            logging.debug("No validation errors detected.")
+            return None
+        except ValidationError as e:
+            logging.debug(f"Validation errors detected: {repr(e)}")
+            return e
+
+    def _load(
+        self, output_model: AindCoreModel, output_directory: Optional[Path]
+    ) -> JobResponse:
+        """
+        Will write to an output directory if an output_directory is not None.
+        If output_directory is None, then the model will be returned as json
+        in the JobResponse object.
+        Parameters
+        ----------
+        output_model : AindCoreModel
+          The final model that has been constructed.
+        output_directory : Optional[Path]
+          Path to write the model to.
+
+        Returns
+        -------
+        JobResponse
+          The JobResponse object with information about the model. The
+          status_codes are:
+          200 - No validation errors on the model and written without errors
+          406 - There were validation errors on the model
+          500 - There were errors writing the model to output_directory
+
+        """
+        validation_errors = self._run_validation_check(output_model)
+        if validation_errors:
+            validation_message = (
+                f"Validation errors detected: {repr(validation_errors)}"
+            )
+            status_code = 406
+        else:
+            validation_message = "No validation errors detected."
+            status_code = 200
+        if output_directory is None:
+            data = output_model.model_dump_json()
+            message = validation_message
+        else:
+            data = None
+            try:
+                output_model.write_standard_file(
+                    output_directory=output_directory
+                )
+                message = (
+                    f"Write model to {output_directory}\n" + validation_message
+                )
+            except Exception as e:
+                message = (
+                    f"Error writing to {output_directory}: {repr(e)}\n"
+                    + validation_message
+                )
+                status_code = 500
+        return JobResponse(status_code=status_code, message=message, data=data)
+
+    @abstractmethod
+    def run_job(self) -> JobResponse:
+        """Abstract method that needs to be implemented by child classes."""
 
 
 # TODO: Deprecated class

--- a/tests/test_legacy_core.py
+++ b/tests/test_legacy_core.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 from unittest import TestCase
+from unittest import main as unittest_main
 from unittest.mock import MagicMock, patch
 
 from aind_data_schema.core.subject import BreedingInfo, Housing, Sex, Subject
@@ -84,3 +85,7 @@ class TestBaseEtl(TestCase):
             "No validation errors detected."
         )
         mock_write.assert_called_once_with(output_directory=Path("out"))
+
+
+if __name__ == "__main__":
+    unittest_main()

--- a/tests/test_legacy_core.py
+++ b/tests/test_legacy_core.py
@@ -1,0 +1,86 @@
+"""Tests legacy BaseEtl class methods. We can remove this once the other jobs
+ are ported over."""
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from aind_data_schema.core.subject import BreedingInfo, Housing, Sex, Subject
+from aind_data_schema.models.organizations import Organization
+from aind_data_schema.models.species import Species
+
+from aind_metadata_mapper.core import BaseEtl
+
+
+class TestBaseEtl(TestCase):
+    """Tests methods in the legacy BaseEtl class."""
+
+    class LegacyEtl(BaseEtl):
+        """Mock a child class"""
+
+        def _extract(self) -> None:
+            """Mocked extract method"""
+            return None
+
+        def _transform(self, extracted_source: Any = None) -> Subject:
+            """Mocked transform method to return an invalid or valid subject
+            model"""
+            if self.input_source != "valid_source":
+                return Subject.model_construct()
+            else:
+                t = datetime(2022, 11, 22, 8, 43, 00)
+
+                s = Subject(
+                    species=Species.MUS_MUSCULUS,
+                    subject_id="12345",
+                    sex=Sex.MALE,
+                    date_of_birth=t.date(),
+                    source=Organization.AI,
+                    breeding_info=BreedingInfo(
+                        breeding_group="Emx1-IRES-Cre(ND)",
+                        maternal_id="546543",
+                        maternal_genotype=(
+                            "Emx1-IRES-Cre/wt; Camk2a-tTa/Camk2a-tTA"
+                        ),
+                        paternal_id="232323",
+                        paternal_genotype="Ai93(TITL-GCaMP6f)/wt",
+                    ),
+                    genotype=(
+                        "Emx1-IRES-Cre/wt;Camk2a-tTA/wt;Ai93(TITL-GCaMP6f)/wt"
+                    ),
+                    housing=Housing(
+                        home_cage_enrichment=["Running wheel"], cage_id="123"
+                    ),
+                    background_strain="C57BL/6J",
+                )
+                return s
+
+    @patch("aind_data_schema.base.AindCoreModel.write_standard_file")
+    @patch("logging.warning")
+    def test_legacy_invalid_model(
+        self, mock_log_warning: MagicMock, mock_write: MagicMock
+    ):
+        """Tests run_job when an invalid model is created."""
+        etl_job = self.LegacyEtl(
+            input_source="source", output_directory=Path("out")
+        )
+        etl_job.run_job()
+        mock_log_warning.assert_called_once()
+        mock_write.assert_called_once_with(output_directory=Path("out"))
+
+    @patch("aind_data_schema.base.AindCoreModel.write_standard_file")
+    @patch("logging.debug")
+    def test_legacy_valid_model(
+        self, mock_log_debug: MagicMock, mock_write: MagicMock
+    ):
+        """Tests run_job when a valid model is created."""
+
+        etl_job = self.LegacyEtl(
+            input_source="valid_source", output_directory=Path("out")
+        )
+        etl_job.run_job()
+        mock_log_debug.assert_called_once_with(
+            "No validation errors detected."
+        )
+        mock_write.assert_called_once_with(output_directory=Path("out"))


### PR DESCRIPTION
Closes #16 

- Updates the interface so that a user defines the job using a pydantic BaseSettings class. The user will need to implement a run_job method
- Adds an extra unit test module for legacy functions that used to be covered by the old bergamo etl tests
- In the future, all jobs should be implemented like:
```python
# not necessary to dump to json, but the option makes it easier to run via a rest request
job_settings_json = user_settings.model_dump_json()
etl_job = BergamoEtl(job_settings=job_settings_json)
job_response = etl_job.run_job()
```