### PR TITLE
feat: updates scripts to pass tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "aind-data-schema==0.26.5",
     "scanimage-tiff-reader==1.4.1.4",
     "tifffile==2024.2.12",
-    "pydantic-settings>=2.0"
+    "pydantic-settings>=2.0",
+    "pillow"
 ]
 
 [project.optional-dependencies]

--- a/src/aind_metadata_mapper/mesoscope/__init__.py
+++ b/src/aind_metadata_mapper/mesoscope/__init__.py
@@ -1,0 +1,1 @@
+"""mesoscope package"""

--- a/tests/resources/mesoscope/expected_session.json
+++ b/tests/resources/mesoscope/expected_session.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
-   "schema_version": "0.1.8",
+   "schema_version": "0.1.4",
    "protocol_id": [],
    "experimenter_full_name": [
       "John Doe"
@@ -49,12 +49,7 @@
                "fov_scale_factor_unit": "um/pixel",
                "frame_rate": "9.48",
                "frame_rate_unit": "hertz",
-               "coupled_fov_index": null,
-               "power": "42",
-               "power_unit": "milliwatt",
-               "scanfield_z": 230,
-               "scanfield_z_unit": "micrometer",
-               "notes": null
+               "coupled_fov_index": null
             },
             {
                "index": 0,
@@ -73,12 +68,7 @@
                "fov_scale_factor_unit": "um/pixel",
                "frame_rate": "9.48",
                "frame_rate_unit": "hertz",
-               "coupled_fov_index": null,
-               "power": "42",
-               "power_unit": "milliwatt",
-               "scanfield_z": 257,
-               "scanfield_z_unit": "micrometer",
-               "notes": null
+               "coupled_fov_index": null
             },
             {
                "index": 1,
@@ -97,12 +87,7 @@
                "fov_scale_factor_unit": "um/pixel",
                "frame_rate": "9.48",
                "frame_rate_unit": "hertz",
-               "coupled_fov_index": null,
-               "power": "28",
-               "power_unit": "milliwatt",
-               "scanfield_z": 176,
-               "scanfield_z_unit": "micrometer",
-               "notes": null
+               "coupled_fov_index": null
             },
             {
                "index": 1,
@@ -121,12 +106,7 @@
                "fov_scale_factor_unit": "um/pixel",
                "frame_rate": "9.48",
                "frame_rate_unit": "hertz",
-               "coupled_fov_index": null,
-               "power": "28",
-               "power_unit": "milliwatt",
-               "scanfield_z": 307,
-               "scanfield_z_unit": "micrometer",
-               "notes": null
+               "coupled_fov_index": null
             },
             {
                "index": 2,
@@ -145,12 +125,7 @@
                "fov_scale_factor_unit": "um/pixel",
                "frame_rate": "9.48",
                "frame_rate_unit": "hertz",
-               "coupled_fov_index": null,
-               "power": "12",
-               "power_unit": "milliwatt",
-               "scanfield_z": 112,
-               "scanfield_z_unit": "micrometer",
-               "notes": null
+               "coupled_fov_index": null
             },
             {
                "index": 2,
@@ -169,12 +144,7 @@
                "fov_scale_factor_unit": "um/pixel",
                "frame_rate": "9.48",
                "frame_rate_unit": "hertz",
-               "coupled_fov_index": null,
-               "power": "12",
-               "power_unit": "milliwatt",
-               "scanfield_z": 351,
-               "scanfield_z_unit": "micrometer",
-               "notes": null
+               "coupled_fov_index": null
             },
             {
                "index": 3,
@@ -193,12 +163,7 @@
                "fov_scale_factor_unit": "um/pixel",
                "frame_rate": "9.48",
                "frame_rate_unit": "hertz",
-               "coupled_fov_index": null,
-               "power": "5",
-               "power_unit": "milliwatt",
-               "scanfield_z": 70,
-               "scanfield_z_unit": "micrometer",
-               "notes": null
+               "coupled_fov_index": null
             },
             {
                "index": 3,
@@ -217,12 +182,7 @@
                "fov_scale_factor_unit": "um/pixel",
                "frame_rate": "9.48",
                "frame_rate_unit": "hertz",
-               "coupled_fov_index": null,
-               "power": "5",
-               "power_unit": "milliwatt",
-               "scanfield_z": 389,
-               "scanfield_z_unit": "micrometer",
-               "notes": null
+               "coupled_fov_index": null
             }
          ],
          "slap_fovs": null,

--- a/tests/test_mesoscope.py
+++ b/tests/test_mesoscope.py
@@ -1,34 +1,42 @@
-import unittest
-from unittest.mock import patch
-import os
-from pathlib import Path
+"""Unit tests for mesoscope etl package"""
+
 import json
+import os
+import unittest
 from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
 from PIL import Image
 
-from aind_metadata_mapper.mesoscope.session import (
-    MesoscopeEtl,
-    JobSettings,
-)
+from aind_metadata_mapper.mesoscope.session import JobSettings, MesoscopeEtl
 
-RESOURCES_DIR = Path(os.path.dirname(os.path.realpath(__file__))) / "resources" / "mesoscope"
+RESOURCES_DIR = (
+    Path(os.path.dirname(os.path.realpath(__file__)))
+    / "resources"
+    / "mesoscope"
+)
 
 EXAMPLE_EXTRACT = RESOURCES_DIR / "example_extract.json"
 EXAMPLE_SESSION = RESOURCES_DIR / "expected_session.json"
 EXAMPLE_PLATFORM = RESOURCES_DIR / "example_platform.json"
 EXAMPLE_IMAGE = RESOURCES_DIR / "test.tiff"
 
+
 class TestMesoscope(unittest.TestCase):
+    """Tests methods in MesoscopeEtl class"""
+
     @classmethod
     def setUpClass(cls) -> None:
+        """Set up the test suite"""
         with open(EXAMPLE_EXTRACT, "r") as f:
             cls.example_extract = json.load(f)
         with open(EXAMPLE_SESSION, "r") as f:
             cls.example_session = json.load(f)
-        cls.example_scanimage_meta ={
+        cls.example_scanimage_meta = {
             "lines_per_frame": 512,
             "pixels_per_line": 512,
-            "fov_scale_factor": 1.0
+            "fov_scale_factor": 1.0,
         }
         cls.example_job_settings = JobSettings(
             input_source=EXAMPLE_PLATFORM,
@@ -44,7 +52,7 @@ class TestMesoscope(unittest.TestCase):
             fov_coordinate_ml=1.5,
             fov_reference="Bregma",
             iacuc_protocol="12345",
-            mouse_platform_name = "disc"
+            mouse_platform_name="disc",
         )
 
     def test_extract(self) -> None:
@@ -57,10 +65,13 @@ class TestMesoscope(unittest.TestCase):
         extract = etl._extract()
         self.assertEqual(extract, expected_extract)
 
-    @patch("aind_metadata_mapper.mesoscope.session.MesoscopeEtl._read_metadata")
+    @patch(
+        "aind_metadata_mapper.mesoscope.session.MesoscopeEtl._read_metadata"
+    )
     @patch("PIL.Image.open")
     def test_transform(self, mock_open, mock_scanimage) -> None:
-        """Tests that the platform json is extracted and transfromed into a session object correctly"""
+        """Tests that the platform json is extracted and transfromed into a
+        session object correctly"""
         etl = MesoscopeEtl(
             job_settings=self.example_job_settings,
         )
@@ -71,14 +82,24 @@ class TestMesoscope(unittest.TestCase):
 
         # mock scanimage metadata
         mock_meta = [{}]
-        mock_meta[0]["SI.hRoiManager.linesPerFrame"] = self.example_scanimage_meta["lines_per_frame"]
-        mock_meta[0]["SI.hRoiManager.pixelsPerLine"]= self.example_scanimage_meta["pixels_per_line"]
-        mock_meta[0]["SI.hRoiManager.scanZoomFactor"] = self.example_scanimage_meta["fov_scale_factor"]
+        mock_meta[0][
+            "SI.hRoiManager.linesPerFrame"
+        ] = self.example_scanimage_meta["lines_per_frame"]
+        mock_meta[0][
+            "SI.hRoiManager.pixelsPerLine"
+        ] = self.example_scanimage_meta["pixels_per_line"]
+        mock_meta[0][
+            "SI.hRoiManager.scanZoomFactor"
+        ] = self.example_scanimage_meta["fov_scale_factor"]
         mock_scanimage.return_value = mock_meta
-        
+
         extract = etl._extract()
         transformed_session = etl._transform(extract)
-        self.assertEqual(json.loads(transformed_session.model_dump_json()), self.example_session)
+
+        self.assertEqual(
+            self.example_session,
+            json.loads(transformed_session.model_dump_json())
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Imports `pillow` dependency in the `pyproject.toml` file
- Adds docstrings for 100% interrogate coverage
- Runs linters and formats docstrings to be less than 79 width
- Changes type signature for class constructor
- Currently, the version of aind-data-schema is pinned to 0.26.5 for this project. The fields in the FOV class are from the latest. I commented those out and removed them from the json example in the test resource folder