### PR TITLE
feat: removes restriction on procedures metadata

### DIFF
--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import List, Optional, Type
@@ -177,7 +178,7 @@ class GatherMetadataJob:
             )
             return contents
 
-    def get_procedures(self) -> dict:
+    def get_procedures(self) -> Optional[dict]:
         """Get procedures metadata"""
         file_name = Procedures.default_filename()
         should_use_service: bool = (
@@ -200,9 +201,10 @@ class GatherMetadataJob:
                 json_content = response.json()
                 return json_content["data"]
             else:
-                raise AssertionError(
+                logging.warning(
                     f"Procedures metadata is not valid! {response.json()}"
                 )
+                return None
         else:
             contents = self._get_file_from_user_defined_directory(
                 file_name=file_name
@@ -470,9 +472,10 @@ class GatherMetadataJob:
             )
         if self.settings.procedures_settings is not None:
             contents = self.get_procedures()
-            self._write_json_file(
-                filename=Procedures.default_filename(), contents=contents
-            )
+            if contents is not None:
+                self._write_json_file(
+                    filename=Procedures.default_filename(), contents=contents
+                )
         if self.settings.raw_data_description_settings is not None:
             contents = self.get_raw_data_description()
             self._write_json_file(

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -224,7 +224,10 @@ class TestGatherMetadataJob(unittest.TestCase):
         mock_get.assert_not_called()
 
     @patch("requests.get")
-    def test_get_procedures_error(self, mock_get: MagicMock):
+    @patch("logging.warning")
+    def test_get_procedures_warning(
+        self, mock_warn: MagicMock, mock_get: MagicMock
+    ):
         """Tests get_procedures when an error is raised"""
         mock_response = Response()
         mock_response.status_code = 500
@@ -240,13 +243,12 @@ class TestGatherMetadataJob(unittest.TestCase):
             ),
         )
         metadata_job = GatherMetadataJob(settings=job_settings)
-        with self.assertRaises(AssertionError) as e:
-            metadata_job.get_procedures()
-        expected_error_message = (
+        output = metadata_job.get_procedures()
+        self.assertIsNone(output)
+        mock_warn.assert_called_once_with(
             "Procedures metadata is not valid! "
             "{'message': 'Internal Server Error'}"
         )
-        self.assertTrue(expected_error_message in str(e.exception))
 
     @patch("requests.get")
     def test_get_raw_data_description(self, mock_get: MagicMock):


### PR DESCRIPTION
Closes #70 

- Removes assertion that procedures metadata needs to be valid
- Adds warning if procedures metadata is not valid