### PR TITLE
build: splits up dependencies into opitonal deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Repository to contain code that will parse source files into aind-data-schema mo
 ## Installation
 To use the software, in the root directory, run
 ```bash
-pip install -e .
+pip install -e .[all]
+```
+
+It's possible to install just a small subset of dependencies. For example,
+```bash
+pip install -e .[bergamo]
 ```
 
 To develop the code, run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ all = [
     "aind-metadata-mapper[bergamo]",
     "aind-metadata-mapper[bruker]",
     "aind-metadata-mapper[mesoscope]",
-    "aind-metadata-mapper[open_ephys]"
+    "aind-metadata-mapper[openephys]"
 ]
 
 bergamo = [
@@ -59,7 +59,7 @@ mesoscope = [
     "tifffile==2024.2.12",
 ]
 
-open_ephys = [
+openephys = [
     "h5py",
     "np_session",
     "npc_ephys",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,32 +19,51 @@ dynamic = ["version"]
 dependencies = [
     "aind-data-schema==0.36.0",
     "aind-data-schema-models==0.1.7",
-    "scanimage-tiff-reader==1.4.1.4",
-    "tifffile==2024.2.12",
     "pydantic-settings>=2.0",
-    "pillow",
-    "bruker2nifti==1.0.4",
-    "requests",
-    "pillow",
-    "h5py",
     "pandas",
     "numpy",
-    "np_session",
-    "npc_ephys",
-    "scipy",
     "pytz"
 ]
 
 [project.optional-dependencies]
 dev = [
-    'black',
-    'coverage',
-    'flake8',
-    'interrogate',
-    'isort',
-    'Sphinx',
-    'furo',
+    "aind-metadata-mapper[all]",
+    "black",
+    "coverage",
+    "flake8",
+    "interrogate",
+    "isort",
+    "Sphinx",
+    "furo",
     "pyyaml>=6.0.0",
+]
+
+all = [
+    "aind-metadata-mapper[bergamo]",
+    "aind-metadata-mapper[bruker]",
+    "aind-metadata-mapper[mesoscope]",
+    "aind-metadata-mapper[open_ephys]"
+]
+
+bergamo = [
+    "scanimage-tiff-reader==1.4.1.4"
+]
+
+bruker = [
+    "bruker2nifti==1.0.4"
+]
+
+mesoscope = [
+    "aind-metadata-mapper[bergamo]",
+    "pillow",
+    "tifffile==2024.2.12",
+]
+
+open_ephys = [
+    "h5py",
+    "np_session",
+    "npc_ephys",
+    "scipy",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/singularity_build.def
+++ b/scripts/singularity_build.def
@@ -8,5 +8,5 @@ Stage: build
 
 %post
     cd ${SINGULARITY_ROOTFS}/aind-metadata-mapper
-    pip install . --no-cache-dir
+    pip install .[all] --no-cache-dir
     rm -rf ${SINGULARITY_ROOTFS}/aind-metadata-mapper


### PR DESCRIPTION
Closes #80 

- Breaks up dependencies so users that only need to run the bergamo etl job don't have to install wavpack-numcodecs, which needs to be done outside of pip