### PR TITLE
fix: smartspim acquisition str to dict

### DIFF
--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -366,7 +366,7 @@ class GatherMetadataJob:
             )
             job_response = acquisition_job.run_job()
             if job_response.status_code != 500:
-                return job_response.data
+                return json.loads(job_response.data)
             else:
                 return None
         else:

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -555,7 +555,7 @@ class TestGatherMetadataJob(unittest.TestCase):
         )
         metadata_job = GatherMetadataJob(settings=job_settings)
         contents = metadata_job.get_acquisition_metadata()
-        self.assertEqual(json.dumps({"some_key": "some_value"}), contents)
+        self.assertEqual({"some_key": "some_value"}, contents)
 
     @patch("aind_metadata_mapper.smartspim.acquisition.SmartspimETL.run_job")
     def test_get_acquisition_metadata_smartspim_error(


### PR DESCRIPTION
- Patches a small issue where the smartspim acquisition is saved as a string instead of a dict