### PR TITLE
change stim_type key to stim_name for listing stim params

### DIFF
--- a/src/aind_metadata_mapper/stimulus/camstim.py
+++ b/src/aind_metadata_mapper/stimulus/camstim.py
@@ -316,11 +316,11 @@ class Camstim:
 
             # if this row is a movie or image set, record it's stim name in
             # the epoch's templates entry
-            stim_type = row.get("stim_type", "")
-            if pd.isnull(stim_type):
-                stim_type = ""
+            stim_name = row.get("stim_name", "")
+            if pd.isnull(stim_name):
+                stim_name = ""
 
-            if "image" in stim_type.lower() or "movie" in stim_type.lower():
+            if "image" in stim_name.lower() or "movie" in stim_name.lower():
                 current_epoch[4].add(row["stim_name"])
 
         # slice off dummy epoch from beginning


### PR DESCRIPTION
I changed the usage of the right key name in the stim table. Previously, was using `stim_type` to check if the stimulus was a movie or image set. However, `stim_type` should probably always be VisualStimulation. `stim_name` is more likely to contain the useful information.