### PR TITLE
support python 3.8 and 3.9

### DIFF
--- a/.github/workflows/run_dev_tests.yml
+++ b/.github/workflows/run_dev_tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ mesoscope = [
     "aind-metadata-mapper[bergamo]",
     "pillow",
     "tifffile==2024.2.12",
-    "mesoscope ; python_version >= '3.10'"
+    "mesoscope ; python_version >= '3.10'",
 ]
 
 openephys = [
@@ -65,7 +65,6 @@ openephys = [
     "scipy",
     "pandas",
     "numpy",
-    "openephys ; python_version >= '3.10'"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,14 @@ dev = [
     "isort",
     "Sphinx",
     "furo",
-    "pyyaml>=6.0.0",
 ]
 
 all = [
     "aind-metadata-mapper[bergamo]",
     "aind-metadata-mapper[bruker]",
     "aind-metadata-mapper[mesoscope]",
-    "aind-metadata-mapper[openephys]"
+    "aind-metadata-mapper[openephys]",
+    "aind-metadata-mapper[dynamicrouting]"
 ]
 
 bergamo = [
@@ -55,7 +55,7 @@ mesoscope = [
     "aind-metadata-mapper[bergamo]",
     "pillow",
     "tifffile==2024.2.12",
-    "mesoscope ; python_version >= '3.10'",
+    "mesoscope ; python_version >= '3.9'",
 ]
 
 openephys = [
@@ -65,6 +65,10 @@ openephys = [
     "scipy",
     "pandas",
     "numpy",
+]
+
+dynamicrouting = [
+    "pyyaml>=6.0.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aind-metadata-mapper"
 description = "Generated from aind-library-template"
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 authors = [
     {name = "Allen Institute for Neural Dynamics"}
 ]
@@ -55,6 +55,7 @@ mesoscope = [
     "aind-metadata-mapper[bergamo]",
     "pillow",
     "tifffile==2024.2.12",
+    "mesoscope ; python_version >= '3.10'"
 ]
 
 openephys = [
@@ -64,6 +65,7 @@ openephys = [
     "scipy",
     "pandas",
     "numpy",
+    "openephys ; python_version >= '3.10'"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "aind-metadata-mapper[all]",
+    "aind-metadata-mapper[all] ; python_version >= '3.9'",
     "black",
     "coverage",
     "flake8",
@@ -39,7 +39,7 @@ all = [
     "aind-metadata-mapper[bruker]",
     "aind-metadata-mapper[mesoscope]",
     "aind-metadata-mapper[openephys]",
-    "aind-metadata-mapper[dynamicrouting]"
+    "aind-metadata-mapper[dynamicrouting]",
 ]
 
 bergamo = [
@@ -55,7 +55,6 @@ mesoscope = [
     "aind-metadata-mapper[bergamo]",
     "pillow",
     "tifffile==2024.2.12",
-    "mesoscope ; python_version >= '3.9'",
 ]
 
 openephys = [


### PR DESCRIPTION
closes #112 

This PR:
- requires python 3.8 to install aind-metadata-mapper
- requires python 3.9 to install aind-metadata-mapper[dev]
- adds 3.9 to python matrix in github actions