### PR TITLE
Feat handle camstim stim blocks

### DIFF
--- a/src/aind_metadata_mapper/open_ephys/utils/stim_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/stim_utils.py
@@ -352,6 +352,30 @@ def make_spontaneous_activity_tables(
     return [spon_sweeps]
 
 
+def extract_blocks_from_stim(stims)
+    """
+    Extracts the blocks from a stim with multiple blocks
+
+    Parameters
+    ----------
+    stims: List[dict]
+        A list of stimuli dictionaries
+
+    Returns
+    -------
+    stim_chunked_blocks: List[dict]
+        A list of stimuli dictionaries with the blocks extracted
+    """
+    stim_chunked_blocks = []
+    for stimulus in stims:
+        if 'stimuli' in stimulus:
+            for stimulus_block in stimulus['stimuli']:
+                stim_chunked_blocks.append(stimulus_block)
+        else:
+            stim_chunked_blocks.append(stimulus)
+    return stim_chunked_blocks
+
+
 def extract_frame_times_from_photodiode(
     sync_file,
     photodiode_cycle=60,

--- a/src/aind_metadata_mapper/open_ephys/utils/stim_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/stim_utils.py
@@ -352,7 +352,7 @@ def make_spontaneous_activity_tables(
     return [spon_sweeps]
 
 
-def extract_blocks_from_stim(stims)
+def extract_blocks_from_stim(stims):
     """
     Extracts the blocks from a stim with multiple blocks
 

--- a/src/aind_metadata_mapper/stimulus/camstim.py
+++ b/src/aind_metadata_mapper/stimulus/camstim.py
@@ -134,8 +134,10 @@ class Camstim:
             duration_threshold=minimum_spontaneous_activity_duration,
         )
 
+        stimuli = pkl.get_stimuli(stim_file)
+        stimuli = stim.extract_blocks_from_stim(stimuli)
         stim_table_sweeps = stim.create_stim_table(
-            stim_file, pkl.get_stimuli(stim_file), stimulus_tabler, spon_tabler
+            stim_file, stimuli, stimulus_tabler, spon_tabler
         )
 
         stim_table_seconds = stim.convert_frames_to_seconds(

--- a/tests/test_open_ephys/test_utils/test_stim_utils.py
+++ b/tests/test_open_ephys/test_utils/test_stim_utils.py
@@ -132,7 +132,6 @@ class TestStimUtils(unittest.TestCase):
         result_df = stim.enforce_df_column_order(empty_df, column_order)
         pd.testing.assert_frame_equal(result_df, empty_df)
 
-
     def test_extract_blocks_from_stim(self):
         """
         Creating a sample pkl dictionary with a "stimuli" block key
@@ -147,7 +146,6 @@ class TestStimUtils(unittest.TestCase):
 
         # Asserting that the result is the "stimuli" key
         self.assertEqual(result, sample_pkl["stimuli"])
-
 
     def test_seconds_to_frames(self):
         """

--- a/tests/test_open_ephys/test_utils/test_stim_utils.py
+++ b/tests/test_open_ephys/test_utils/test_stim_utils.py
@@ -136,9 +136,7 @@ class TestStimUtils(unittest.TestCase):
         """
         Creating a sample pkl dictionary with a "stimuli" block key
         """
-        sample_pkl = {
-            "stimuli": ["image1.jpg", "image2.jpg", "image3.jpg"],
-            "other_key": "other_value",
+        sample_pkl = {["image1.jpg", "image2.jpg", "image3.jpg"]
         }
 
         # Calling the function with the sample pkl dictionary

--- a/tests/test_open_ephys/test_utils/test_stim_utils.py
+++ b/tests/test_open_ephys/test_utils/test_stim_utils.py
@@ -132,6 +132,23 @@ class TestStimUtils(unittest.TestCase):
         result_df = stim.enforce_df_column_order(empty_df, column_order)
         pd.testing.assert_frame_equal(result_df, empty_df)
 
+
+    def test_extract_blocks_from_stim(self):
+        """
+        Creating a sample pkl dictionary with a "stimuli" block key
+        """
+        sample_pkl = {
+            "stimuli": ["image1.jpg", "image2.jpg", "image3.jpg"],
+            "other_key": "other_value",
+        }
+
+        # Calling the function with the sample pkl dictionary
+        result = stim.extract_blocks_from_stim(sample_pkl)
+
+        # Asserting that the result is the "stimuli" key
+        self.assertEqual(result, sample_pkl["stimuli"])
+
+
     def test_seconds_to_frames(self):
         """
         Test the seconds_to_frames function.

--- a/tests/test_open_ephys/test_utils/test_stim_utils.py
+++ b/tests/test_open_ephys/test_utils/test_stim_utils.py
@@ -136,14 +136,13 @@ class TestStimUtils(unittest.TestCase):
         """
         Creating a sample pkl dictionary with a "stimuli" block key
         """
-        sample_pkl = {["image1.jpg", "image2.jpg", "image3.jpg"]
-        }
+        sample_pkl = ["image1.jpg", "image2.jpg", "image3.jpg"]
 
         # Calling the function with the sample pkl dictionary
         result = stim.extract_blocks_from_stim(sample_pkl)
 
         # Asserting that the result is the "stimuli" key
-        self.assertEqual(result, sample_pkl["stimuli"])
+        self.assertEqual(result, sample_pkl)
 
     def test_seconds_to_frames(self):
         """


### PR DESCRIPTION
Adds the ability to handle camstim projects which have their stim encoded using stim blocks within the ['stim'] field. Relatively simple change.