### PR TITLE
Feat 143 path strings

### DIFF
--- a/src/aind_metadata_mapper/bergamo/models.py
+++ b/src/aind_metadata_mapper/bergamo/models.py
@@ -1,10 +1,7 @@
 """Module defining JobSettings for Bergamo ETL"""
 
 from decimal import Decimal
-from pathlib import Path
 from typing import List, Literal, Optional
-
-from pydantic import Field
 
 from aind_metadata_mapper.core import BaseJobSettings
 
@@ -14,16 +11,6 @@ class JobSettings(BaseJobSettings):
     BERGAMO prefix or set explicitly."""
 
     job_settings_name: Literal["Bergamo"] = "Bergamo"
-    input_source: Path = Field(
-        ..., description="Directory of files that need to be parsed."
-    )
-    output_directory: Optional[Path] = Field(
-        default=None,
-        description=(
-            "Directory where to save the json file to. If None, then json"
-            " contents will be returned in the Response message."
-        ),
-    )
     # mandatory fields:
     experimenter_full_name: List[str]
     subject_id: str

--- a/src/aind_metadata_mapper/bergamo/session.py
+++ b/src/aind_metadata_mapper/bergamo/session.py
@@ -80,23 +80,6 @@ class RawImageInfo:
 class BergamoEtl(GenericEtl[JobSettings]):
     """Class to manage transforming bergamo data files into a Session object"""
 
-    def __init__(
-        self,
-        job_settings: Union[JobSettings, str],
-    ):
-        """
-        Class constructor for Base etl class.
-        Parameters
-        ----------
-        job_settings: Union[JobSettings, str]
-          Variables for a particular session
-        """
-        if isinstance(job_settings, str):
-            job_settings_model = JobSettings.model_validate_json(job_settings)
-        else:
-            job_settings_model = job_settings
-        super().__init__(job_settings=job_settings_model)
-
     def get_tif_file_locations(self) -> Dict[str, List[Path]]:
         """Scans the input source directory and returns a dictionary of file
         groups in an ordered list. For example, if the directory had
@@ -1169,5 +1152,6 @@ class BergamoEtl(GenericEtl[JobSettings]):
 
 if __name__ == "__main__":
     sys_args = sys.argv[1:]
-    etl = BergamoEtl.from_args(sys_args)
+    job_settings = JobSettings.from_args(sys_args)
+    etl = BergamoEtl(job_settings=job_settings)
     etl.run_job()

--- a/src/aind_metadata_mapper/bergamo/session.py
+++ b/src/aind_metadata_mapper/bergamo/session.py
@@ -80,6 +80,22 @@ class RawImageInfo:
 class BergamoEtl(GenericEtl[JobSettings]):
     """Class to manage transforming bergamo data files into a Session object"""
 
+    # TODO: Deprecate this constructor. Use GenericEtl constructor instead
+    def __init__(self, job_settings: Union[JobSettings, str]):
+        """
+        Class constructor for Base etl class.
+        Parameters
+        ----------
+        job_settings: Union[JobSettings, str]
+          Variables for a particular session
+        """
+
+        if isinstance(job_settings, str):
+            job_settings_model = JobSettings.model_validate_json(job_settings)
+        else:
+            job_settings_model = job_settings
+        super().__init__(job_settings=job_settings_model)
+
     def get_tif_file_locations(self) -> Dict[str, List[Path]]:
         """Scans the input source directory and returns a dictionary of file
         groups in an ordered list. For example, if the directory had
@@ -1152,6 +1168,6 @@ class BergamoEtl(GenericEtl[JobSettings]):
 
 if __name__ == "__main__":
     sys_args = sys.argv[1:]
-    job_settings = JobSettings.from_args(sys_args)
-    etl = BergamoEtl(job_settings=job_settings)
+    main_job_settings = JobSettings.from_args(sys_args)
+    etl = BergamoEtl(job_settings=main_job_settings)
     etl.run_job()

--- a/src/aind_metadata_mapper/bruker/models.py
+++ b/src/aind_metadata_mapper/bruker/models.py
@@ -1,6 +1,6 @@
 """Module defining JobSettings for Bruker ETL"""
-
-from typing import List, Literal
+from pathlib import Path
+from typing import List, Literal, Optional, Union
 
 from aind_data_schema.components.devices import (
     MagneticStrength,
@@ -15,6 +15,9 @@ class JobSettings(BaseJobSettings):
     """Data that needs to be input by user."""
 
     job_settings_name: Literal["Bruker"] = "Bruker"
+    data_path: Optional[Union[Path, str]] = Field(
+        default=None, description=("Deprecated, use input_source instead.")
+    )
     experimenter_full_name: List[str]
     protocol_id: str = Field(default="", description="Protocol ID")
     collection_tz: str = Field(

--- a/src/aind_metadata_mapper/bruker/models.py
+++ b/src/aind_metadata_mapper/bruker/models.py
@@ -1,7 +1,6 @@
 """Module defining JobSettings for Bruker ETL"""
 
-from pathlib import Path
-from typing import List, Literal, Optional
+from typing import List, Literal
 
 from aind_data_schema.components.devices import (
     MagneticStrength,
@@ -16,14 +15,14 @@ class JobSettings(BaseJobSettings):
     """Data that needs to be input by user."""
 
     job_settings_name: Literal["Bruker"] = "Bruker"
-    data_path: Path
-    output_directory: Optional[Path] = Field(
-        default=None,
-        description=(
-            "Directory where to save the json file to. If None, then json"
-            " contents will be returned in the Response message."
-        ),
-    )
+    # data_path: Path
+    # output_directory: Optional[Path] = Field(
+    #     default=None,
+    #     description=(
+    #         "Directory where to save the json file to. If None, then json"
+    #         " contents will be returned in the Response message."
+    #     ),
+    # )
     experimenter_full_name: List[str]
     protocol_id: str = Field(default="", description="Protocol ID")
     collection_tz: str = Field(

--- a/src/aind_metadata_mapper/bruker/models.py
+++ b/src/aind_metadata_mapper/bruker/models.py
@@ -15,14 +15,6 @@ class JobSettings(BaseJobSettings):
     """Data that needs to be input by user."""
 
     job_settings_name: Literal["Bruker"] = "Bruker"
-    # data_path: Path
-    # output_directory: Optional[Path] = Field(
-    #     default=None,
-    #     description=(
-    #         "Directory where to save the json file to. If None, then json"
-    #         " contents will be returned in the Response message."
-    #     ),
-    # )
     experimenter_full_name: List[str]
     protocol_id: str = Field(default="", description="Protocol ID")
     collection_tz: str = Field(

--- a/src/aind_metadata_mapper/core.py
+++ b/src/aind_metadata_mapper/core.py
@@ -199,7 +199,6 @@ class BaseJobSettings(BaseSettings):
 
         return tuple(sources)
 
-    # TODO: The following can probably be abstracted
     @classmethod
     def from_args(cls, args: list):
         """

--- a/src/aind_metadata_mapper/core.py
+++ b/src/aind_metadata_mapper/core.py
@@ -7,7 +7,17 @@ from abc import ABC, abstractmethod
 from functools import cached_property
 from os import PathLike
 from pathlib import Path
-from typing import Any, Dict, Generic, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from aind_data_schema.base import AindCoreModel
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -18,8 +28,6 @@ from pydantic_settings import (
     InitSettingsSource,
     PydanticBaseSettingsSource,
 )
-
-_T = TypeVar("_T", bound=BaseSettings)
 
 
 class JobResponse(BaseModel):
@@ -136,6 +144,25 @@ class JsonConfigSettingsSource(PydanticBaseSettingsSource):
 class BaseJobSettings(BaseSettings):
     """Parent class for generating settings from a config file."""
 
+    job_settings_name: str = Field(
+        ...,
+        description=(
+            "Literal name for job settings to make serialized class distinct."
+        ),
+    )
+    input_source: Optional[Union[Path, str, List[str], List[Path]]] = Field(
+        default=None,
+        description=(
+            "Location or locations of data sources to parse for metadata."
+        ),
+    )
+    output_directory: Optional[Union[Path, str]] = Field(
+        default=None,
+        description=(
+            "Location to metadata file data to. None to return object."
+        ),
+    )
+
     user_settings_config_file: Optional[Union[Path, str]] = Field(
         default=None,
         repr=False,
@@ -172,6 +199,43 @@ class BaseJobSettings(BaseSettings):
 
         return tuple(sources)
 
+    # TODO: The following can probably be abstracted
+    @classmethod
+    def from_args(cls, args: list):
+        """
+        Adds ability to construct settings from a list of arguments.
+        Parameters
+        ----------
+        args : list
+        A list of command line arguments to parse.
+        """
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-j",
+            "--job-settings",
+            required=True,
+            type=str,
+            help=(
+                r"""
+                Custom settings defined by the user defined as a json
+                 string. For example: -j
+                 '{
+                 "input_source":"/directory/to/read/from",
+                 "output_directory":"/directory/to/write/to",
+                 "job_settings_name": "Bergamo"}'
+                """
+            ),
+        )
+        job_args = parser.parse_args(args)
+        job_settings_from_args = cls.model_validate_json(job_args.job_settings)
+        return cls(
+            job_settings=job_settings_from_args,
+        )
+
+
+_T = TypeVar("_T", bound=BaseJobSettings)
+
 
 class GenericEtl(ABC, Generic[_T]):
     """A generic etl class. Child classes will need to create a JobSettings
@@ -187,6 +251,18 @@ class GenericEtl(ABC, Generic[_T]):
           Generic type that is bound by the BaseSettings class.
         """
         self.job_settings = job_settings
+        if isinstance(self.job_settings.input_source, str):
+            self.job_settings.input_source = Path(
+                self.job_settings.input_source
+            )
+        elif isinstance(self.job_settings.input_source, list):
+            self.job_settings.input_source = [
+                Path(p) for p in self.job_settings.input_source
+            ]
+        if isinstance(self.job_settings.output_directory, str):
+            self.job_settings.output_directory = Path(
+                self.job_settings.output_directory
+            )
 
     @staticmethod
     def _run_validation_check(

--- a/src/aind_metadata_mapper/fip/models.py
+++ b/src/aind_metadata_mapper/fip/models.py
@@ -1,10 +1,7 @@
 """Module defining JobSettings for FIP ETL"""
 
 from datetime import datetime
-from pathlib import Path
-from typing import List, Literal, Optional
-
-from pydantic import Field
+from typing import List, Literal
 
 from aind_metadata_mapper.core import BaseJobSettings
 
@@ -13,13 +10,6 @@ class JobSettings(BaseJobSettings):
     """Data that needs to be input by user."""
 
     job_settings_name: Literal["FIP"] = "FIP"
-    output_directory: Optional[Path] = Field(
-        default=None,
-        description=(
-            "Directory where to save the json file to. If None, then json"
-            " contents will be returned in the Response message."
-        ),
-    )
 
     string_to_parse: str
     experimenter_full_name: List[str]

--- a/src/aind_metadata_mapper/fip/session.py
+++ b/src/aind_metadata_mapper/fip/session.py
@@ -1,9 +1,9 @@
 """Module to write valid OptoStim and Subject schemas"""
 
 import re
+import sys
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Union
 
 from aind_data_schema.components.stimulus import OptoStimulation, PulseShape
 from aind_data_schema.core.session import (
@@ -45,23 +45,6 @@ class FIBEtl(GenericEtl[JobSettings]):
     duration_regex = re.compile(r"OptoDuration\(s\):\s*([0-9.]+)")
     interval_regex = re.compile(r"OptoInterval\(s\):\s*([0-9.]+)")
     base_regex = re.compile(r"OptoBase\(s\):\s*([0-9.]+)")
-
-    def __init__(
-        self,
-        job_settings: Union[JobSettings, str],
-    ):
-        """
-        Class constructor for Base etl class.
-        Parameters
-        ----------
-        job_settings: Union[JobSettings, str]
-          Variables for a particular session
-        """
-        if isinstance(job_settings, str):
-            job_settings_model = JobSettings.model_validate_json(job_settings)
-        else:
-            job_settings_model = job_settings
-        super().__init__(job_settings=job_settings_model)
 
     def _transform(self, extracted_source: ParsedMetadata) -> Session:
         """
@@ -213,3 +196,10 @@ class FIBEtl(GenericEtl[JobSettings]):
             transformed, self.job_settings.output_directory
         )
         return job_response
+
+
+if __name__ == "__main__":
+    sys_args = sys.argv[1:]
+    job_settings = JobSettings.from_args(sys_args)
+    etl = FIBEtl(job_settings=job_settings)
+    etl.run_job()

--- a/src/aind_metadata_mapper/fip/session.py
+++ b/src/aind_metadata_mapper/fip/session.py
@@ -4,6 +4,7 @@ import re
 import sys
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import Union
 
 from aind_data_schema.components.stimulus import OptoStimulation, PulseShape
 from aind_data_schema.core.session import (
@@ -45,6 +46,22 @@ class FIBEtl(GenericEtl[JobSettings]):
     duration_regex = re.compile(r"OptoDuration\(s\):\s*([0-9.]+)")
     interval_regex = re.compile(r"OptoInterval\(s\):\s*([0-9.]+)")
     base_regex = re.compile(r"OptoBase\(s\):\s*([0-9.]+)")
+
+    # TODO: Deprecate this constructor. Use GenericEtl constructor instead
+    def __init__(self, job_settings: Union[JobSettings, str]):
+        """
+        Class constructor for Base etl class.
+        Parameters
+        ----------
+        job_settings: Union[JobSettings, str]
+          Variables for a particular session
+        """
+
+        if isinstance(job_settings, str):
+            job_settings_model = JobSettings.model_validate_json(job_settings)
+        else:
+            job_settings_model = job_settings
+        super().__init__(job_settings=job_settings_model)
 
     def _transform(self, extracted_source: ParsedMetadata) -> Session:
         """
@@ -200,6 +217,6 @@ class FIBEtl(GenericEtl[JobSettings]):
 
 if __name__ == "__main__":
     sys_args = sys.argv[1:]
-    job_settings = JobSettings.from_args(sys_args)
-    etl = FIBEtl(job_settings=job_settings)
+    main_job_settings = JobSettings.from_args(sys_args)
+    etl = FIBEtl(job_settings=main_job_settings)
     etl.run_job()

--- a/src/aind_metadata_mapper/mesoscope/models.py
+++ b/src/aind_metadata_mapper/mesoscope/models.py
@@ -13,10 +13,8 @@ class JobSettings(BaseJobSettings):
     """Data to be entered by the user."""
 
     job_settings_name: Literal["Mesoscope"] = "Mesoscope"
-    # input_source: Path
     # TODO: Can probably put this as part of input_source
     behavior_source: Union[Path, str]
-    # output_directory: Path
     session_start_time: datetime
     session_end_time: datetime
     subject_id: str

--- a/src/aind_metadata_mapper/mesoscope/models.py
+++ b/src/aind_metadata_mapper/mesoscope/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from pathlib import Path
-from typing import List, Literal
+from typing import List, Literal, Union
 
 from pydantic import Field
 
@@ -13,9 +13,10 @@ class JobSettings(BaseJobSettings):
     """Data to be entered by the user."""
 
     job_settings_name: Literal["Mesoscope"] = "Mesoscope"
-    input_source: Path
-    behavior_source: Path
-    output_directory: Path
+    # input_source: Path
+    # TODO: Can probably put this as part of input_source
+    behavior_source: Union[Path, str]
+    # output_directory: Path
     session_start_time: datetime
     session_end_time: datetime
     subject_id: str

--- a/src/aind_metadata_mapper/models.py
+++ b/src/aind_metadata_mapper/models.py
@@ -7,6 +7,7 @@ from aind_data_schema.core.processing import PipelineProcess
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic_settings import BaseSettings
 from typing_extensions import Annotated
 
 from aind_metadata_mapper.bergamo.models import (
@@ -15,7 +16,6 @@ from aind_metadata_mapper.bergamo.models import (
 from aind_metadata_mapper.bruker.models import (
     JobSettings as BrukerSessionJobSettings,
 )
-from aind_metadata_mapper.core import BaseJobSettings
 from aind_metadata_mapper.fip.models import (
     JobSettings as FipSessionJobSettings,
 )
@@ -36,7 +36,7 @@ class JobResponse(BaseModel):
     data: Optional[str] = Field(None)
 
 
-class SessionSettings(BaseJobSettings):
+class SessionSettings(BaseSettings):
     """Settings needed to retrieve session metadata"""
 
     job_settings: Annotated[
@@ -50,7 +50,7 @@ class SessionSettings(BaseJobSettings):
     ]
 
 
-class AcquisitionSettings(BaseJobSettings):
+class AcquisitionSettings(BaseSettings):
     """Fields needed to retrieve acquisition metadata"""
 
     # TODO: we can change this to a tagged union once more acquisition settings
@@ -58,21 +58,21 @@ class AcquisitionSettings(BaseJobSettings):
     job_settings: SmartSpimAcquisitionJobSettings
 
 
-class SubjectSettings(BaseJobSettings):
+class SubjectSettings(BaseSettings):
     """Fields needed to retrieve subject metadata"""
 
     subject_id: str
     metadata_service_path: str = "subject"
 
 
-class ProceduresSettings(BaseJobSettings):
+class ProceduresSettings(BaseSettings):
     """Fields needed to retrieve procedures metadata"""
 
     subject_id: str
     metadata_service_path: str = "procedures"
 
 
-class RawDataDescriptionSettings(BaseJobSettings):
+class RawDataDescriptionSettings(BaseSettings):
     """Fields needed to retrieve data description metadata"""
 
     name: str
@@ -82,13 +82,13 @@ class RawDataDescriptionSettings(BaseJobSettings):
     metadata_service_path: str = "funding"
 
 
-class ProcessingSettings(BaseJobSettings):
+class ProcessingSettings(BaseSettings):
     """Fields needed to retrieve processing metadata"""
 
     pipeline_process: PipelineProcess
 
 
-class MetadataSettings(BaseJobSettings):
+class MetadataSettings(BaseSettings):
     """Fields needed to retrieve main Metadata"""
 
     name: str
@@ -103,7 +103,7 @@ class MetadataSettings(BaseJobSettings):
     instrument_filepath: Optional[Path] = None
 
 
-class JobSettings(BaseJobSettings):
+class JobSettings(BaseSettings):
     """Fields needed to gather all metadata"""
 
     job_settings_name: Literal["GatherMetadata"] = "GatherMetadata"

--- a/src/aind_metadata_mapper/open_ephys/camstim_ephys_session.py
+++ b/src/aind_metadata_mapper/open_ephys/camstim_ephys_session.py
@@ -16,11 +16,7 @@ import npc_sessions
 import numpy as np
 import pandas as pd
 from aind_data_schema.components.coordinates import Coordinates3d
-from aind_data_schema.core.session import (
-    ManipulatorModule,
-    Session,
-    Stream,
-)
+from aind_data_schema.core.session import ManipulatorModule, Session, Stream
 from aind_data_schema_models.modalities import Modality
 
 import aind_metadata_mapper.open_ephys.utils.constants as constants

--- a/src/aind_metadata_mapper/open_ephys/utils/behavior_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/behavior_utils.py
@@ -730,9 +730,9 @@ def fix_omitted_end_frame(stim_pres_table: pd.DataFrame) -> pd.DataFrame:
         stim_pres_table[stim_pres_table["omitted"]]["start_frame"]
         + median_stim_frame_duration
     )
-    stim_pres_table.loc[stim_pres_table["omitted"], "end_frame"] = (
-        omitted_end_frames
-    )
+    stim_pres_table.loc[
+        stim_pres_table["omitted"], "end_frame"
+    ] = omitted_end_frames
 
     stim_dtypes = stim_pres_table.dtypes.to_dict()
     stim_dtypes["start_frame"] = int
@@ -796,9 +796,9 @@ def compute_is_sham_change(
                 if np.array_equal(
                     active_images, stim_image_names[passive_block_mask].values
                 ):
-                    stim_df.loc[passive_block_mask, "is_sham_change"] = (
-                        stim_df[active_block_mask]["is_sham_change"].values
-                    )
+                    stim_df.loc[
+                        passive_block_mask, "is_sham_change"
+                    ] = stim_df[active_block_mask]["is_sham_change"].values
 
     return stim_df.sort_index()
 

--- a/src/aind_metadata_mapper/open_ephys/utils/stim_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/stim_utils.py
@@ -368,8 +368,8 @@ def extract_blocks_from_stim(stims):
     """
     stim_chunked_blocks = []
     for stimulus in stims:
-        if 'stimuli' in stimulus:
-            for stimulus_block in stimulus['stimuli']:
+        if "stimuli" in stimulus:
+            for stimulus_block in stimulus["stimuli"]:
                 stim_chunked_blocks.append(stimulus_block)
         else:
             stim_chunked_blocks.append(stimulus)

--- a/src/aind_metadata_mapper/smartspim/acquisition.py
+++ b/src/aind_metadata_mapper/smartspim/acquisition.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Union
 
 from aind_data_schema.components.coordinates import ImageAxis
 from aind_data_schema.core import acquisition
@@ -25,6 +25,29 @@ class SmartspimETL(GenericEtl[JobSettings]):
     This class contains the methods to write the metadata
     for a SmartSPIM session
     """
+
+    # TODO: Deprecate this constructor. Use GenericEtl constructor instead
+    def __init__(self, job_settings: Union[JobSettings, str]):
+        """
+        Class constructor for Base etl class.
+        Parameters
+        ----------
+        job_settings: Union[JobSettings, str]
+          Variables for a particular session
+        """
+
+        if isinstance(job_settings, str):
+            job_settings_model = JobSettings.model_validate_json(job_settings)
+        else:
+            job_settings_model = job_settings
+        if (
+            job_settings_model.raw_dataset_path is not None
+            and job_settings_model.input_source is None
+        ):
+            job_settings_model.input_source = (
+                job_settings_model.raw_dataset_path
+            )
+        super().__init__(job_settings=job_settings_model)
 
     REGEX_DATE = (
         r"(20[0-9]{2})-([0-9]{2})-([0-9]{2})_([0-9]{2})-"
@@ -242,6 +265,6 @@ class SmartspimETL(GenericEtl[JobSettings]):
 
 if __name__ == "__main__":
     sys_args = sys.argv[1:]
-    job_settings = JobSettings.from_args(sys_args)
-    etl = SmartspimETL(job_settings=job_settings)
+    main_job_settings = JobSettings.from_args(sys_args)
+    etl = SmartspimETL(job_settings=main_job_settings)
     etl.run_job()

--- a/src/aind_metadata_mapper/smartspim/models.py
+++ b/src/aind_metadata_mapper/smartspim/models.py
@@ -1,7 +1,6 @@
 """Module defining JobSettings for SmartSPIM ETL"""
 
-from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal
 
 from aind_metadata_mapper.core import BaseJobSettings
 
@@ -13,8 +12,7 @@ class JobSettings(BaseJobSettings):
     job_settings_name: Literal["SmartSPIM"] = "SmartSPIM"
 
     subject_id: str
-    raw_dataset_path: Path
-    output_directory: Optional[Path] = None
+    # raw_dataset_path: Path
 
     # Metadata names
     asi_filename: str = "derivatives/ASI_logging.txt"

--- a/src/aind_metadata_mapper/smartspim/models.py
+++ b/src/aind_metadata_mapper/smartspim/models.py
@@ -12,7 +12,6 @@ class JobSettings(BaseJobSettings):
     job_settings_name: Literal["SmartSPIM"] = "SmartSPIM"
 
     subject_id: str
-    # raw_dataset_path: Path
 
     # Metadata names
     asi_filename: str = "derivatives/ASI_logging.txt"

--- a/src/aind_metadata_mapper/smartspim/models.py
+++ b/src/aind_metadata_mapper/smartspim/models.py
@@ -1,6 +1,8 @@
 """Module defining JobSettings for SmartSPIM ETL"""
+from pathlib import Path
+from typing import Literal, Optional, Union
 
-from typing import Literal
+from pydantic import Field
 
 from aind_metadata_mapper.core import BaseJobSettings
 
@@ -10,7 +12,9 @@ class JobSettings(BaseJobSettings):
 
     # Field can be used to switch between different acquisition etl jobs
     job_settings_name: Literal["SmartSPIM"] = "SmartSPIM"
-
+    raw_dataset_path: Optional[Union[Path, str]] = Field(
+        default=None, description=("Deprecated, use input_source instead.")
+    )
     subject_id: str
 
     # Metadata names

--- a/src/aind_metadata_mapper/u19/models.py
+++ b/src/aind_metadata_mapper/u19/models.py
@@ -1,25 +1,18 @@
 """Defines Job Settings for U19 ETL"""
 
-from pathlib import Path
-from typing import List, Literal, Optional
+from typing import List, Literal
 
 from pydantic import Field
-from pydantic_settings import BaseSettings
+
+from aind_metadata_mapper.core import BaseJobSettings
 
 
-class JobSettings(BaseSettings):
+class JobSettings(BaseJobSettings):
     """Data that needs to be input by user."""
 
     job_settings_name: Literal["U19"] = "U19"
-    tissue_sheet_path: Path
+    # tissue_sheet_path: Path
     tissue_sheet_names: List[str]
-    output_directory: Optional[Path] = Field(
-        default=None,
-        description=(
-            "Directory where to save the json file to. If None, then json"
-            " contents will be returned in the Response message."
-        ),
-    )
     experimenter_full_name: List[str]
     subject_to_ingest: str = Field(
         default=None,

--- a/src/aind_metadata_mapper/u19/models.py
+++ b/src/aind_metadata_mapper/u19/models.py
@@ -1,6 +1,6 @@
 """Defines Job Settings for U19 ETL"""
-
-from typing import List, Literal
+from pathlib import Path
+from typing import List, Literal, Optional, Union
 
 from pydantic import Field
 
@@ -11,6 +11,9 @@ class JobSettings(BaseJobSettings):
     """Data that needs to be input by user."""
 
     job_settings_name: Literal["U19"] = "U19"
+    tissue_sheet_path: Optional[Union[Path, str]] = Field(
+        default=None, description=("Deprecated, use input_source instead.")
+    )
     tissue_sheet_names: List[str]
     experimenter_full_name: List[str]
     subject_to_ingest: str = Field(

--- a/src/aind_metadata_mapper/u19/models.py
+++ b/src/aind_metadata_mapper/u19/models.py
@@ -11,7 +11,6 @@ class JobSettings(BaseJobSettings):
     """Data that needs to be input by user."""
 
     job_settings_name: Literal["U19"] = "U19"
-    # tissue_sheet_path: Path
     tissue_sheet_names: List[str]
     experimenter_full_name: List[str]
     subject_to_ingest: str = Field(

--- a/src/aind_metadata_mapper/u19/procedures.py
+++ b/src/aind_metadata_mapper/u19/procedures.py
@@ -3,7 +3,6 @@
 import json
 import logging
 from datetime import datetime
-from typing import Union
 
 import pandas as pd
 import requests
@@ -34,21 +33,6 @@ def strings_to_dates(strings):
 
 class U19Etl(GenericEtl[JobSettings]):
     """U19 ETL class."""
-
-    def __init__(self, job_settings: Union[JobSettings, str]):
-        """
-        Class constructor for Base etl class.
-        Parameters
-        ----------
-        job_settings: Union[JobSettings, str]
-          Variables for a particular session
-        """
-
-        if isinstance(job_settings, str):
-            job_settings_model = JobSettings.model_validate_json(job_settings)
-        else:
-            job_settings_model = job_settings
-        super().__init__(job_settings=job_settings_model)
 
     def run_job(self) -> JobResponse:
         """Run the job and return the response."""
@@ -82,9 +66,9 @@ class U19Etl(GenericEtl[JobSettings]):
             if row is None:
                 logging.warning(f"Could not find row for {subj_id}")
                 return
-            existing_procedure["specimen_procedures"] = (
-                self.extract_spec_procedures(subj_id, row)
-            )
+            existing_procedure[
+                "specimen_procedures"
+            ] = self.extract_spec_procedures(subj_id, row)
 
             return construct_new_model(
                 existing_procedure,
@@ -157,7 +141,7 @@ class U19Etl(GenericEtl[JobSettings]):
 
         for sheet_name in self.job_settings.tissue_sheet_names:
             df = pd.read_excel(
-                self.job_settings.tissue_sheet_path,
+                self.job_settings.input_source,
                 sheet_name=sheet_name,
                 header=[0, 1, 2],
             )

--- a/tests/test_U19/test_procedures.py
+++ b/tests/test_U19/test_procedures.py
@@ -50,7 +50,7 @@ class TestU19Writer(unittest.TestCase):
             self.example_output = json.load(f)
 
         self.example_job_settings = JobSettings(
-            tissue_sheet_path=EXAMPLE_TISSUE_SHEET,
+            input_source=EXAMPLE_TISSUE_SHEET,
             tissue_sheet_names=[
                 "example_sheet",
                 "extra sheet",
@@ -60,15 +60,6 @@ class TestU19Writer(unittest.TestCase):
             subject_to_ingest="721832",
             allow_validation_errors=True,
         )
-
-    def test_constructor_from_string(self) -> None:
-        """Test constructor from string."""
-
-        job_settings_string = self.example_job_settings.model_dump_json()
-        etl0 = U19Etl(self.example_job_settings)
-        etl1 = U19Etl(job_settings_string)
-
-        self.assertEqual(etl1.job_settings, etl0.job_settings)
 
     @patch(
         "aind_metadata_mapper.u19.procedures.U19Etl.download_procedure_file"
@@ -248,3 +239,7 @@ class TestU19Writer(unittest.TestCase):
 
         self.assertEqual(len(extracted_procedures), 6)
         self.assertEqual(extracted_procedures[5], test_spec_procedure)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bergamo/test_session.py
+++ b/tests/test_bergamo/test_session.py
@@ -52,15 +52,6 @@ class TestBergamoEtl(unittest.TestCase):
         }
         self.assertEqual(expected_paths, locations)
 
-    def test_class_constructor(self):
-        """Tests that the class can be constructed from a json string"""
-        settings1 = self.example_job_settings.model_copy(deep=True)
-        json_str = settings1.model_dump_json()
-        etl_job1 = BergamoEtl(
-            job_settings=json_str,
-        )
-        self.assertEqual(settings1, etl_job1.job_settings)
-
     def test_flat_dict_to_nested(self):
         """Test util method to convert dictionaries from flat to nested."""
         original_input = {

--- a/tests/test_bergamo/test_session.py
+++ b/tests/test_bergamo/test_session.py
@@ -43,6 +43,15 @@ class TestBergamoEtl(unittest.TestCase):
         )
         cls.expected_session = expected_session_contents
 
+    def test_class_constructor(self):
+        """Tests that the class can be constructed from a json string"""
+        settings1 = self.example_job_settings.model_copy(deep=True)
+        json_str = settings1.model_dump_json()
+        etl_job1 = BergamoEtl(
+            job_settings=json_str,
+        )
+        self.assertEqual(settings1, etl_job1.job_settings)
+
     def test_get_tif_file_locations(self):
         """Tests _get_tif_file_locations method"""
         etl = BergamoEtl(job_settings=self.example_job_settings)

--- a/tests/test_bruker/test_session.py
+++ b/tests/test_bruker/test_session.py
@@ -95,6 +95,15 @@ class TestMRIWriter(unittest.TestCase):
         cls.example_etl = example_etl
         cls.example_model = example_model
 
+    def test_constructor_from_string(self) -> None:
+        """Test constructor from string."""
+
+        job_settings_string = self.example_job_settings.model_dump_json()
+        etl0 = MRIEtl(self.example_job_settings)
+        etl1 = MRIEtl(job_settings_string)
+
+        self.assertEqual(etl1.job_settings, etl0.job_settings)
+
     @patch(
         "aind_metadata_mapper.bruker.session.BrukerMetadata",
         new=MockBrukerMetadata,

--- a/tests/test_bruker/test_session.py
+++ b/tests/test_bruker/test_session.py
@@ -75,8 +75,8 @@ class TestMRIWriter(unittest.TestCase):
 
         cls.expected_session = contents
 
-        cls.example_job_settings = JobSettings(
-            data_path="some_data_path",
+        example_job_settings = JobSettings(
+            input_source="some_data_path",
             experimenter_full_name=["fake mae"],
             primary_scan_number=7,
             setup_scan_number=1,
@@ -89,19 +89,11 @@ class TestMRIWriter(unittest.TestCase):
             session_notes="test",
             collection_tz="US/Pacific",
         )
-
-        cls.example_etl = MRIEtl(cls.example_job_settings)
-
-        cls.example_model = cls.example_etl._extract()
-
-    def test_constructor_from_string(self) -> None:
-        """Test constructor from string."""
-
-        job_settings_string = self.example_job_settings.model_dump_json()
-        etl0 = MRIEtl(self.example_job_settings)
-        etl1 = MRIEtl(job_settings_string)
-
-        self.assertEqual(etl1.job_settings, etl0.job_settings)
+        example_etl = MRIEtl(job_settings=example_job_settings)
+        example_model = example_etl._extract()
+        cls.example_job_settings = example_job_settings
+        cls.example_etl = example_etl
+        cls.example_model = example_model
 
     @patch(
         "aind_metadata_mapper.bruker.session.BrukerMetadata",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ import json
 import os
 import unittest
 from pathlib import Path
+from typing import Literal
 from unittest.mock import MagicMock, patch
 
 from aind_metadata_mapper.core import BaseJobSettings
@@ -19,6 +20,7 @@ class TestJobSettings(unittest.TestCase):
     class MockJobSettings(BaseJobSettings):
         """Mock class for testing purposes"""
 
+        job_settings_name: Literal["mock_job"] = "mock_job"
         name: str
         id: int
 
@@ -26,10 +28,12 @@ class TestJobSettings(unittest.TestCase):
         """Test job settings can be loaded from config file."""
 
         job_settings = self.MockJobSettings(
-            user_settings_config_file=CONFIG_FILE_PATH
+            job_settings_name="mock_job",
+            user_settings_config_file=CONFIG_FILE_PATH,
         )
         expected_settings_json = json.dumps(
             {
+                "job_settings_name": "mock_job",
                 "user_settings_config_file": str(CONFIG_FILE_PATH),
                 "name": "Anna Apple",
                 "id": 12345,

--- a/tests/test_fip/test_session.py
+++ b/tests/test_fip/test_session.py
@@ -85,17 +85,6 @@ class TestSchemaWriter(unittest.TestCase):
             json.dumps(expected_session_contents)
         )
 
-    def test_constructor_from_string(self) -> None:
-        """Tests that the settings can be constructed from a json string"""
-        job_settings_str = self.example_job_settings.model_dump_json()
-        etl0 = FIBEtl(
-            job_settings=job_settings_str,
-        )
-        etl1 = FIBEtl(
-            job_settings=self.example_job_settings,
-        )
-        self.assertEqual(etl1.job_settings, etl0.job_settings)
-
     def test_extract(self):
         """Tests that the teensy response and experiment
         data is extracted correctly"""

--- a/tests/test_fip/test_session.py
+++ b/tests/test_fip/test_session.py
@@ -85,6 +85,17 @@ class TestSchemaWriter(unittest.TestCase):
             json.dumps(expected_session_contents)
         )
 
+    def test_constructor_from_string(self) -> None:
+        """Tests that the settings can be constructed from a json string"""
+        job_settings_str = self.example_job_settings.model_dump_json()
+        etl0 = FIBEtl(
+            job_settings=job_settings_str,
+        )
+        etl1 = FIBEtl(
+            job_settings=self.example_job_settings,
+        )
+        self.assertEqual(etl1.job_settings, etl0.job_settings)
+
     def test_extract(self):
         """Tests that the teensy response and experiment
         data is extracted correctly"""

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -559,7 +559,7 @@ class TestGatherMetadataJob(unittest.TestCase):
             status_code=200, data=json.dumps({"some_key": "some_value"})
         )
         mesoscope_session_settings = (
-            MesoscopeSessionJobSettings.model_construct()
+            MesoscopeSessionJobSettings.model_construct(behavior_source="abc")
         )
         job_settings = JobSettings(
             directory_to_write_to=RESOURCES_DIR,

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -668,9 +668,7 @@ class TestGatherMetadataJob(unittest.TestCase):
             acquisition_settings=AcquisitionSettings(
                 job_settings=SmartSpimAcquisitionJobSettings(
                     subject_id="695464",
-                    raw_dataset_path=Path(
-                        "SmartSPIM_695464_2023-10-18_20-30-30"
-                    ),
+                    input_source=Path("SmartSPIM_695464_2023-10-18_20-30-30"),
                 )
             ),
         )
@@ -692,9 +690,7 @@ class TestGatherMetadataJob(unittest.TestCase):
             acquisition_settings=AcquisitionSettings(
                 job_settings=SmartSpimAcquisitionJobSettings(
                     subject_id="695464",
-                    raw_dataset_path=Path(
-                        "SmartSPIM_695464_2023-10-18_20-30-30"
-                    ),
+                    input_source=Path("SmartSPIM_695464_2023-10-18_20-30-30"),
                 )
             ),
         )

--- a/tests/test_mesoscope/test_session.py
+++ b/tests/test_mesoscope/test_session.py
@@ -64,6 +64,17 @@ class TestMesoscope(unittest.TestCase):
             mouse_platform_name="disc",
         )
 
+    def test_constructor_from_string(self) -> None:
+        """Tests that the settings can be constructed from a json string"""
+        job_settings_str = self.example_job_settings.model_dump_json()
+        etl0 = MesoscopeEtl(
+            job_settings=job_settings_str,
+        )
+        etl1 = MesoscopeEtl(
+            job_settings=self.example_job_settings,
+        )
+        self.assertEqual(etl1.job_settings, etl0.job_settings)
+
     @patch("pathlib.Path.is_file")
     def test_read_metadata_value_error(self, mock_is_file: MagicMock) -> None:
         """Tests that _read_metadata raises a ValueError"""

--- a/tests/test_mesoscope/test_session.py
+++ b/tests/test_mesoscope/test_session.py
@@ -64,17 +64,6 @@ class TestMesoscope(unittest.TestCase):
             mouse_platform_name="disc",
         )
 
-    def test_constructor_from_string(self) -> None:
-        """Tests that the settings can be constructed from a json string"""
-        job_settings_str = self.example_job_settings.model_dump_json()
-        etl0 = MesoscopeEtl(
-            job_settings=job_settings_str,
-        )
-        etl1 = MesoscopeEtl(
-            job_settings=self.example_job_settings,
-        )
-        self.assertEqual(etl1.job_settings, etl0.job_settings)
-
     @patch("pathlib.Path.is_file")
     def test_read_metadata_value_error(self, mock_is_file: MagicMock) -> None:
         """Tests that _read_metadata raises a ValueError"""
@@ -177,15 +166,15 @@ class TestMesoscope(unittest.TestCase):
 
         # mock scanimage metadata
         mock_meta = [{}]
-        mock_meta[0]["SI.hRoiManager.linesPerFrame"] = (
-            self.example_scanimage_meta["lines_per_frame"]
-        )
-        mock_meta[0]["SI.hRoiManager.pixelsPerLine"] = (
-            self.example_scanimage_meta["pixels_per_line"]
-        )
-        mock_meta[0]["SI.hRoiManager.scanZoomFactor"] = (
-            self.example_scanimage_meta["fov_scale_factor"]
-        )
+        mock_meta[0][
+            "SI.hRoiManager.linesPerFrame"
+        ] = self.example_scanimage_meta["lines_per_frame"]
+        mock_meta[0][
+            "SI.hRoiManager.pixelsPerLine"
+        ] = self.example_scanimage_meta["pixels_per_line"]
+        mock_meta[0][
+            "SI.hRoiManager.scanZoomFactor"
+        ] = self.example_scanimage_meta["fov_scale_factor"]
         mock_scanimage.return_value = mock_meta
 
         extract = etl._extract()

--- a/tests/test_open_ephys/test_rig.py
+++ b/tests/test_open_ephys/test_rig.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from aind_data_schema.core.rig import Rig  # type: ignore
-from aind_metadata_mapper.open_ephys.rig import OpenEphysRigEtl
 
+from aind_metadata_mapper.open_ephys.rig import OpenEphysRigEtl
 
 RESOURCES_DIR = (
     Path(os.path.dirname(os.path.realpath(__file__))) / ".." / "resources"

--- a/tests/test_smartspim/test_acquisition.py
+++ b/tests/test_smartspim/test_acquisition.py
@@ -27,7 +27,7 @@ class TestSmartspimETL(unittest.TestCase):
         """Setting up temporary folder directory"""
         self.example_job_settings_success = JobSettings(
             subject_id="000000",
-            input_source="/SmartSPIM_000000_2024-10-10_10-10-10",
+            input_source="SmartSPIM_000000_2024-10-10_10-10-10",
             output_directory="output_folder",
             asi_filename="derivatives/ASI_logging.txt",
             mdata_filename_json="derivatives/metadata.json",
@@ -39,7 +39,7 @@ class TestSmartspimETL(unittest.TestCase):
 
         self.example_job_settings_fail_mouseid = JobSettings(
             subject_id="00000",
-            input_source="/SmartSPIM_00000_2024-10-10_10-10-10",
+            input_source="SmartSPIM_00000_2024-10-10_10-10-10",
             output_directory="output_folder",
             asi_filename="derivatives/ASI_logging.txt",
             mdata_filename_json="derivatives/metadata.json",
@@ -48,6 +48,15 @@ class TestSmartspimETL(unittest.TestCase):
         self.example_smartspim_etl_fail_mouseid = SmartspimETL(
             job_settings=self.example_job_settings_fail_mouseid
         )
+
+    def test_class_constructor(self):
+        """Tests that the class can be constructed from a json string"""
+        settings1 = self.example_job_settings_success.model_copy(deep=True)
+        json_str = settings1.model_dump_json()
+        etl_job1 = SmartspimETL(
+            job_settings=json_str,
+        )
+        self.assertEqual(settings1, etl_job1.job_settings)
 
     @patch("aind_metadata_mapper.smartspim.acquisition.SmartspimETL._extract")
     def test_extract(self, mock_extract: MagicMock):

--- a/tests/test_smartspim/test_acquisition.py
+++ b/tests/test_smartspim/test_acquisition.py
@@ -27,8 +27,8 @@ class TestSmartspimETL(unittest.TestCase):
         """Setting up temporary folder directory"""
         self.example_job_settings_success = JobSettings(
             subject_id="000000",
-            raw_dataset_path="/SmartSPIM_000000_2024-10-10_10-10-10",
-            output_directory="/output_folder",
+            input_source="/SmartSPIM_000000_2024-10-10_10-10-10",
+            output_directory="output_folder",
             asi_filename="derivatives/ASI_logging.txt",
             mdata_filename_json="derivatives/metadata.json",
             processing_manifest_path="derivatives/processing_manifest.json",
@@ -39,8 +39,8 @@ class TestSmartspimETL(unittest.TestCase):
 
         self.example_job_settings_fail_mouseid = JobSettings(
             subject_id="00000",
-            raw_dataset_path="/SmartSPIM_00000_2024-10-10_10-10-10",
-            output_directory="/output_folder",
+            input_source="/SmartSPIM_00000_2024-10-10_10-10-10",
+            output_directory="output_folder",
             asi_filename="derivatives/ASI_logging.txt",
             mdata_filename_json="derivatives/metadata.json",
             processing_manifest_path="derivatives/processing_manifest.json",
@@ -48,15 +48,6 @@ class TestSmartspimETL(unittest.TestCase):
         self.example_smartspim_etl_fail_mouseid = SmartspimETL(
             job_settings=self.example_job_settings_fail_mouseid
         )
-
-    def test_class_constructor(self):
-        """Tests that the class can be constructed from a json string"""
-        settings1 = self.example_job_settings_success.model_copy(deep=True)
-        json_str = settings1.model_dump_json()
-        etl_job1 = SmartspimETL(
-            job_settings=json_str,
-        )
-        self.assertEqual(settings1, etl_job1.job_settings)
 
     @patch("aind_metadata_mapper.smartspim.acquisition.SmartspimETL._extract")
     def test_extract(self, mock_extract: MagicMock):


### PR DESCRIPTION
Closes #143 

- Sets paths to optional paths or strings
- Has main etl jobs inherit common class to reduce duplicated code
- Marked this as a breaking change since I renamed a few fields that can be the same across all jobs settings. For example, I renamed `raw_data_path` in the SmartSPIM JobSettings to `input_source` via the parent class.