### PR TITLE
user-defined subj_id for missing subj_id

### DIFF
--- a/src/aind_metadata_mapper/u19/procedures.py
+++ b/src/aind_metadata_mapper/u19/procedures.py
@@ -173,7 +173,7 @@ class U19Etl(GenericEtl[JobSettings]):
             )
             self.tissue_sheets.append(df)
 
-    def extract_spec_procedures(self, subj_id, row):  # noqa: C901
+    def extract_spec_procedures(self, input_subj_id, row):  # noqa: C901
         """Extract the specimen procedures from the spreadsheet."""
 
         default_source = Organization.LIFECANVAS
@@ -183,6 +183,9 @@ class U19Etl(GenericEtl[JobSettings]):
             .strip()
             .lower()
         )
+
+        if not isinstance(subj_id, int):
+            subj_id = input_subj_id
 
         experimenter = row["SubjInfo"]["Unnamed: 2_level_1"][
             "Experimenter"


### PR DESCRIPTION
slight tweak to allow use for cases where the subj_id is not present on the sheet, but is known in some other way