### PR TITLE
pin to 1.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ all = [
 ]
 
 schema = [
-    "aind-data-schema>=1.0.0,<2.0",
+    "aind-data-schema>=1.1.1,<2.0",
     "pydantic<2.9"
 ]
 

--- a/tests/resources/dynamic_routing/base-missing-probe_rig.json
+++ b/tests/resources/dynamic_routing/base-missing-probe_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
-   "schema_version": "1.0.0",
+   "schema_version": "1.0.1",
    "rig_id": "327_NP2_20240401",
    "modification_date": "2024-04-01",
    "mouse_platform": {

--- a/tests/resources/dynamic_routing/base_rig.json
+++ b/tests/resources/dynamic_routing/base_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
-   "schema_version": "1.0.0",
+   "schema_version": "1.0.1",
    "rig_id": "327_NP2_20240401",
    "modification_date": "2024-04-01",
    "mouse_platform": {

--- a/tests/resources/open_ephys/open-ephys-inferred_rig.json
+++ b/tests/resources/open_ephys/open-ephys-inferred_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
-   "schema_version": "1.0.0",
+   "schema_version": "1.0.1",
    "rig_id": "327_NP2_20240401",
    "modification_date": "2024-04-01",
    "mouse_platform": {

--- a/tests/resources/open_ephys/open-ephys_rig.json
+++ b/tests/resources/open_ephys/open-ephys_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
-   "schema_version": "1.0.0",
+   "schema_version": "1.0.1",
    "rig_id": "327_NP2_20240401",
    "modification_date": "2024-04-01",
    "mouse_platform": {

--- a/tests/test_bergamo/test_session.py
+++ b/tests/test_bergamo/test_session.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from aind_data_schema.core.session import Session
 from aind_metadata_mapper.bergamo.session import BergamoEtl, JobSettings
 
 RESOURCES_DIR = (
@@ -41,6 +42,9 @@ class TestBergamoEtl(unittest.TestCase):
             fov_targeted_structure="Primary Motor Cortex",
             notes="test upload",
         )
+        expected_session_contents["schema_version"] = Session.model_fields[
+            "schema_version"
+        ].default
         cls.expected_session = expected_session_contents
 
     def test_class_constructor(self):

--- a/tests/test_bruker/test_session.py
+++ b/tests/test_bruker/test_session.py
@@ -16,7 +16,7 @@ from aind_data_schema.components.devices import (
     MagneticStrength,
     ScannerLocation,
 )
-
+from aind_data_schema.core.session import Session
 from aind_metadata_mapper.bruker.session import JobSettings, MRIEtl
 
 RESOURCES_DIR = (
@@ -73,6 +73,9 @@ class TestMRIWriter(unittest.TestCase):
         with open(EXPECTED_SESSION, "r") as f:
             contents = json.load(f)
 
+        contents["schema_version"] = Session.model_fields[
+            "schema_version"
+        ].default
         cls.expected_session = contents
 
         example_job_settings = JobSettings(

--- a/tests/test_dynamic_routing/test_mvr_rig.py
+++ b/tests/test_dynamic_routing/test_mvr_rig.py
@@ -1,10 +1,12 @@
 """Tests for the MVR rig ETL."""
 
 import os
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from aind_data_schema.core.rig import Rig
 from aind_metadata_mapper.dynamic_routing.mvr_rig import (  # type: ignore
     MvrRigEtl,
 )
@@ -16,6 +18,8 @@ RESOURCES_DIR = (
     / "resources"
     / "dynamic_routing"
 )
+
+MVR_PATH = Path(RESOURCES_DIR / "mvr_rig.json")
 
 
 class TestMvrRigEtl(unittest.TestCase):
@@ -76,13 +80,14 @@ class TestMvrRigEtl(unittest.TestCase):
 
     def setUp(self):
         """Sets up test resources."""
-        (
-            self.input_source,
-            self.output_dir,
-            self.expected,
-        ) = test_utils.setup_neuropixels_etl_resources(
-            RESOURCES_DIR / "mvr_rig.json",
-        )
+        self.input_source = RESOURCES_DIR / "base_rig.json"
+        self.output_dir = Path("abc")
+        with open(MVR_PATH, "r") as f:
+            mvr_contents = json.load(f)
+        mvr_contents["schema_version"] = Rig.model_fields[
+            "schema_version"
+        ].default
+        self.expected = Rig(**mvr_contents)
 
 
 if __name__ == "__main__":

--- a/tests/test_dynamic_routing/test_sync_rig.py
+++ b/tests/test_dynamic_routing/test_sync_rig.py
@@ -1,6 +1,7 @@
 """Tests for Sync rig ETL."""
 
 import os
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -8,7 +9,7 @@ from unittest.mock import MagicMock, patch
 from aind_metadata_mapper.dynamic_routing.sync_rig import (  # type: ignore
     SyncRigEtl,
 )
-from tests.test_dynamic_routing import test_utils as test_utils
+from aind_data_schema.core.rig import Rig
 
 RESOURCES_DIR = (
     Path(os.path.dirname(os.path.realpath(__file__)))
@@ -16,6 +17,7 @@ RESOURCES_DIR = (
     / "resources"
     / "dynamic_routing"
 )
+SYNC_PATH = Path(RESOURCES_DIR / "sync_rig.json")
 
 
 class TestSyncRigEtl(unittest.TestCase):
@@ -51,13 +53,14 @@ class TestSyncRigEtl(unittest.TestCase):
 
     def setUp(self):
         """Sets up test resources."""
-        (
-            self.input_source,
-            self.output_dir,
-            self.expected,
-        ) = test_utils.setup_neuropixels_etl_resources(
-            RESOURCES_DIR / "sync_rig.json"
-        )
+        self.input_source = RESOURCES_DIR / "base_rig.json"
+        self.output_dir = Path("abc")
+        with open(SYNC_PATH, "r") as f:
+            mvr_contents = json.load(f)
+        mvr_contents["schema_version"] = Rig.model_fields[
+            "schema_version"
+        ].default
+        self.expected = Rig(**mvr_contents)
 
 
 if __name__ == "__main__":

--- a/tests/test_fip/test_session.py
+++ b/tests/test_fip/test_session.py
@@ -80,7 +80,9 @@ class TestSchemaWriter(unittest.TestCase):
             mouse_platform_name="Disc",
             active_mouse_platform=False,
         )
-
+        expected_session_contents["schema_version"] = Session.model_fields[
+            "schema_version"
+        ].default
         cls.expected_session = Session.model_validate_json(
             json.dumps(expected_session_contents)
         )

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -1031,13 +1031,13 @@ class TestGatherMetadataJob(unittest.TestCase):
         """Tests that users can set a session config file when requesting
         GatherMetadataJob"""
 
+        bergamo_settings = BergamoSessionJobSettings(
+            user_settings_config_file=EXAMPLE_BERGAMO_CONFIGS
+        )
         test_configs = {
             "directory_to_write_to": RESOURCES_DIR,
             "session_settings": {
-                "job_settings": {
-                    "job_settings_name": "Bergamo",
-                    "user_settings_config_file": EXAMPLE_BERGAMO_CONFIGS,
-                }
+                "job_settings": bergamo_settings.model_dump(),
             },
         }
         job_settings = JobSettings.model_validate_json(

--- a/tests/test_mesoscope/test_session.py
+++ b/tests/test_mesoscope/test_session.py
@@ -37,7 +37,11 @@ class TestMesoscope(unittest.TestCase):
         with open(EXAMPLE_EXTRACT, "r") as f:
             cls.example_extract = json.load(f)
         with open(EXAMPLE_SESSION, "r") as f:
-            cls.example_session = json.load(f)
+            expected_session = json.load(f)
+        expected_session["schema_version"] = Session.model_fields[
+            "schema_version"
+        ].default
+        cls.example_session = expected_session
         cls.example_scanimage_meta = {
             "lines_per_frame": 512,
             "pixels_per_line": 512,
@@ -177,15 +181,15 @@ class TestMesoscope(unittest.TestCase):
 
         # mock scanimage metadata
         mock_meta = [{}]
-        mock_meta[0][
-            "SI.hRoiManager.linesPerFrame"
-        ] = self.example_scanimage_meta["lines_per_frame"]
-        mock_meta[0][
-            "SI.hRoiManager.pixelsPerLine"
-        ] = self.example_scanimage_meta["pixels_per_line"]
-        mock_meta[0][
-            "SI.hRoiManager.scanZoomFactor"
-        ] = self.example_scanimage_meta["fov_scale_factor"]
+        mock_meta[0]["SI.hRoiManager.linesPerFrame"] = (
+            self.example_scanimage_meta["lines_per_frame"]
+        )
+        mock_meta[0]["SI.hRoiManager.pixelsPerLine"] = (
+            self.example_scanimage_meta["pixels_per_line"]
+        )
+        mock_meta[0]["SI.hRoiManager.scanZoomFactor"] = (
+            self.example_scanimage_meta["fov_scale_factor"]
+        )
         mock_scanimage.return_value = mock_meta
 
         extract = etl._extract()

--- a/tests/test_open_ephys/test_rig.py
+++ b/tests/test_open_ephys/test_rig.py
@@ -1,6 +1,7 @@
 """Tests for the dynamic_routing open open_ephys rig ETL."""
 
 import os
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -27,9 +28,12 @@ class TestOpenEphysRigEtl(unittest.TestCase):
 
     def load_rig(self, model_path: Path):
         """Convenience function to load a rig model."""
-        return Rig.model_validate_json(
-            (model_path).read_text(),
-        )
+        with open(model_path, "r") as f:
+            expected_rig = json.load(f)
+        expected_rig["schema_version"] = Rig.model_fields[
+            "schema_version"
+        ].default
+        return Rig(**expected_rig)
 
     def test_transform(self):
         """Tests etl transform."""


### PR DESCRIPTION
closes #182 
- Updates data-schema lower bound to 1.1.1
- Updates session from config test because the nested model_validation was breaking 
- Replaces schema_version in examples with model's default