### PR TITLE
fix: parses latest funding schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ all = [
 ]
 
 schema = [
-    "aind-data-schema>=1.2.0,<2.0",
+    "aind-data-schema>=1.2.0,<1.3.0",
 ]
 
 bergamo = [

--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -12,7 +12,6 @@ from aind_data_schema.base import AindCoreModel
 from aind_data_schema.core.acquisition import Acquisition
 from aind_data_schema.core.data_description import (
     DataDescription,
-    Funding,
     RawDataDescription,
 )
 from aind_data_schema.core.instrument import Instrument
@@ -176,9 +175,7 @@ class GatherMetadataJob:
                 if project_investigators is not [""]:
                     investigators.update(investigators_pid_names)
                 funding_info_without_investigators = {
-                    k: v
-                    for k, v in f.items()
-                    if k != "investigators"
+                    k: v for k, v in f.items() if k != "investigators"
                 }
                 parsed_funding_info.append(funding_info_without_investigators)
             investigators = [

--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -12,6 +12,7 @@ from aind_data_schema.base import AindCoreModel
 from aind_data_schema.core.acquisition import Acquisition
 from aind_data_schema.core.data_description import (
     DataDescription,
+    Funding,
     RawDataDescription,
 )
 from aind_data_schema.core.instrument import Instrument
@@ -161,23 +162,30 @@ class GatherMetadataJob:
             else:
                 funding_info = []
             investigators = set()
+            parsed_funding_info = []
             for f in funding_info:
-                project_fundees = (
+                project_investigators = (
                     ""
-                    if f.get("fundee", None) is None
-                    else f.get("fundee", "").split(",")
+                    if f.get("investigators", None) is None
+                    else f.get("investigators", "").split(",")
                 )
-                pid_names = [
+                investigators_pid_names = [
                     PIDName(name=p.strip()).model_dump_json()
-                    for p in project_fundees
+                    for p in project_investigators
                 ]
-                if project_fundees is not [""]:
-                    investigators.update(pid_names)
+                if project_investigators is not [""]:
+                    investigators.update(investigators_pid_names)
+                funding_info_without_investigators = {
+                    k: v
+                    for k, v in f.items()
+                    if k != "investigators"
+                }
+                parsed_funding_info.append(funding_info_without_investigators)
             investigators = [
                 PIDName.model_validate_json(i) for i in investigators
             ]
             investigators.sort(key=lambda x: x.name)
-            return funding_info, investigators
+            return parsed_funding_info, investigators
 
         # Returns a dict with platform, subject_id, and acq_datetime
         file_name = RawDataDescription.default_filename()

--- a/tests/resources/gather_metadata_job/example_funding_multiple_response.json
+++ b/tests/resources/gather_metadata_job/example_funding_multiple_response.json
@@ -12,7 +12,8 @@
         "registry_identifier": "03cpe7c52"
       },
       "grant_number": null,
-      "fundee": "Anna Apple, John Smith"
+      "fundee": "Anna Apple, John Smith",
+      "investigators": "Anna Apple"
     },
     {
       "funder": {
@@ -25,7 +26,8 @@
         "registry_identifier": "01s5ya894"
       },
       "grant_number": "1U01NS133760",
-      "fundee": "Anna Apple, John Smith, Don Key"
+      "fundee": "Anna Apple, John Smith, Don Key",
+      "investigators": null
     }
   ]
 }

--- a/tests/resources/gather_metadata_job/example_funding_response.json
+++ b/tests/resources/gather_metadata_job/example_funding_response.json
@@ -11,6 +11,7 @@
       "registry_identifier": "03cpe7c52"
     },
     "grant_number": null,
-    "fundee": "Anna Apple, John Smith"
+    "fundee": "Anna Apple, John Smith",
+    "investigators": "Anna Apple"
   }
 }

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -290,7 +290,7 @@ class TestGatherMetadataJob(unittest.TestCase):
         )
         metadata_job = GatherMetadataJob(settings=job_settings)
         contents = metadata_job.get_raw_data_description()
-        expected_investigators = ["Anna Apple", "John Smith"]
+        expected_investigators = ["Anna Apple"]
         actual_investigators = [i["name"] for i in contents["investigators"]]
         self.assertEqual(expected_investigators, actual_investigators)
         self.assertEqual("ecephys", contents["platform"]["abbreviation"])
@@ -360,7 +360,7 @@ class TestGatherMetadataJob(unittest.TestCase):
         )
         metadata_job = GatherMetadataJob(settings=job_settings)
         contents = metadata_job.get_raw_data_description()
-        expected_investigators = ["Anna Apple", "Don Key", "John Smith"]
+        expected_investigators = ["Anna Apple"]
         actual_investigators = [i["name"] for i in contents["investigators"]]
         self.assertEqual(2, len(contents["funding_source"]))
         self.assertEqual(expected_investigators, actual_investigators)
@@ -782,7 +782,8 @@ class TestGatherMetadataJob(unittest.TestCase):
         metadata_job._gather_non_automated_metadata()
         mock_write_file.assert_called()
 
-    def test_get_main_metadata_with_warnings(self):
+    @patch("logging.warning")
+    def test_get_main_metadata_with_warnings(self, mock_warn: MagicMock):
         """Tests get_main_metadata method raises validation warnings"""
         job_settings = JobSettings(
             directory_to_write_to=RESOURCES_DIR,
@@ -812,6 +813,7 @@ class TestGatherMetadataJob(unittest.TestCase):
         )
         self.assertEqual("Missing", main_metadata["metadata_status"])
         self.assertEqual("632269", main_metadata["subject"]["subject_id"])
+        mock_warn.assert_called_once()
 
     @patch("logging.warning")
     def test_get_main_metadata_with_ser_issues(self, mock_log: MagicMock):


### PR DESCRIPTION
Closes #225 

- Parses latest funding info schema
- Parses investigators from new investigators key instead of fundees key.
- Latest aind-data-schema v1.3.0 raises a bunch of errors. Added upper bound to version.