### PR TITLE
Bug fix/remove byte decoding

### DIFF
--- a/src/aind_metadata_mapper/open_ephys/utils/behavior_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/behavior_utils.py
@@ -90,11 +90,10 @@ def get_images_dict(pkl_dict) -> Dict:
     images_meta = []
 
     for cat, cat_images in image_set.items():
-        cat_decoded = cat.decode("utf-8")
         for img_index, (img_name, img) in enumerate(cat_images.items()):
             meta = {
-                "image_category": cat_decoded,
-                "image_name": img_name.decode("utf-8"),
+                "image_category": cat,
+                "image_name": img_name,
                 "orientation": np.NaN,
                 "phase": np.NaN,
                 "spatial_frequency": np.NaN,

--- a/src/aind_metadata_mapper/open_ephys/utils/pkl_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/pkl_utils.py
@@ -34,7 +34,7 @@ def load_img_pkl(pstream):
         image pkl file.
 
     """
-    return pickle.load(pstream, encoding="bytes")
+    return pickle.load(pstream, encoding="Latin-1")
 
 
 def get_stimuli(pkl):


### PR DESCRIPTION
This removes decoding of type "bytes" for the img pickle path that is pointed toward by the behavior pickle file. Tested using '/allen/programs/mindscope/production/openscope/prod0/specimen_1400574834/ophys_session_1417115172/1417115172.pkl' and '/allen/programs/mindscope/production/openscope/prod0/specimen_1400574834/ophys_session_1417115172/1417115172_20250129T094614.h5' and confirmed that the old bytes error does not occur any longer.

Resolves #234  