### PR TITLE
Bug fix/avoid mtrain stage url

### DIFF
--- a/src/aind_metadata_mapper/open_ephys/utils/pkl_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/pkl_utils.py
@@ -112,6 +112,25 @@ def angular_wheel_velocity(pkl):
     return get_fps(pkl) * get_angular_wheel_rotation(pkl)
 
 
+def get_stage(pkl):
+    """
+    Returns the stage from a pkl file
+
+    Parameters
+    ----------
+    pkl : dict
+        pkl file.
+
+    Returns
+    -------
+    data: str
+        stage name
+    """
+    if 'stage' in pkl:
+        return pkl["stage"]
+    elif 'items' in pkl:
+        return pkl['items']["behavior"]['cl_params']["stage"]
+
 def get_angular_wheel_rotation(pkl):
     """
     Returns the wheel rotation from a pkl file

--- a/src/aind_metadata_mapper/open_ephys/utils/pkl_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/pkl_utils.py
@@ -126,10 +126,11 @@ def get_stage(pkl):
     data: str
         stage name
     """
-    if 'stage' in pkl:
+    if "stage" in pkl:
         return pkl["stage"]
-    elif 'items' in pkl:
-        return pkl['items']["behavior"]['cl_params']["stage"]
+    elif "items" in pkl:
+        return pkl["items"]["behavior"]["cl_params"]["stage"]
+
 
 def get_angular_wheel_rotation(pkl):
     """

--- a/src/aind_metadata_mapper/stimulus/camstim.py
+++ b/src/aind_metadata_mapper/stimulus/camstim.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Optional
 
 import pandas as pd
-import requests
 from aind_data_schema.components.devices import Software
 from aind_data_schema.core.session import (
     StimulusEpoch,

--- a/src/aind_metadata_mapper/stimulus/camstim.py
+++ b/src/aind_metadata_mapper/stimulus/camstim.py
@@ -130,8 +130,6 @@ class Camstim:
         """Returns the session uuid from the pickle file"""
         return pkl.load_pkl(self.pkl_path)["session_uuid"]
 
-
-
     def get_stim_table_seconds(
         self, stim_table_sweeps, frame_times, name_map
     ) -> pd.DataFrame:
@@ -304,10 +302,7 @@ class Camstim:
             url="https://eng-gitlab.corp.alleninstitute.org/braintv/camstim",
         )
 
-        script_obj = Software(
-            name=self.stage_name,
-            version="1.0"
-        )
+        script_obj = Software(name=self.stage_name, version="1.0")
 
         print("STIM PATH", self.stim_table_path)
         schema_epochs = []

--- a/src/aind_metadata_mapper/stimulus/camstim.py
+++ b/src/aind_metadata_mapper/stimulus/camstim.py
@@ -33,7 +33,6 @@ class CamstimSettings(BaseModel):
     sessions_root: Optional[Path] = None
     opto_conditions_map: Optional[dict] = None
     overwrite_tables: bool = False
-    mtrain_server: str = "http://mtrain:5000"
     input_source: Path
     output_directory: Optional[Path]
     session_id: str
@@ -61,7 +60,6 @@ class Camstim:
         self.sync_path = None
         self.sync_data = None
         self.camstim_settings = camstim_settings
-        self.mtrain_server = self.camstim_settings.mtrain_server
         self.input_source = Path(self.camstim_settings.input_source)
         session_id = self.camstim_settings.session_id
         self.pkl_path = next(self.input_source.rglob("*.pkl"))
@@ -73,11 +71,11 @@ class Camstim:
         )
         self.pkl_data = pkl.load_pkl(self.pkl_path)
         self.fps = pkl.get_fps(self.pkl_data)
+        self.stage_name = pkl.get_stage(self.pkl_data)
         self.session_start, self.session_end = self._get_sync_times()
         self.sync_data = sync.load_sync(self.sync_path)
         self.mouse_id = self.camstim_settings.subject_id
         self.session_uuid = self.get_session_uuid()
-        self.mtrain_regimen = self.get_mtrain()
         self.behavior = self._is_behavior()
         self.session_type = self._get_session_type()
 
@@ -132,12 +130,7 @@ class Camstim:
         """Returns the session uuid from the pickle file"""
         return pkl.load_pkl(self.pkl_path)["session_uuid"]
 
-    def get_mtrain(self) -> dict:
-        """Returns dictionary containing 'id', 'name', 'stages', 'states'"""
-        server = self.mtrain_server
-        req = f"{server}/behavior_session/{self.session_uuid}/details"
-        mtrain_response = requests.get(req).json()
-        return mtrain_response["result"]["regimen"]
+
 
     def get_stim_table_seconds(
         self, stim_table_sweeps, frame_times, name_map
@@ -312,9 +305,8 @@ class Camstim:
         )
 
         script_obj = Software(
-            name=self.mtrain_regimen["name"],
-            version="1.0",
-            url=self.mtrain_regimen["script"],
+            name=self.stage_name,
+            version="1.0"
         )
 
         print("STIM PATH", self.stim_table_path)

--- a/tests/test_mesoscope/test_session.py
+++ b/tests/test_mesoscope/test_session.py
@@ -84,7 +84,7 @@ class TestMesoscope(unittest.TestCase):
             job_settings=job_settings_str,
         )
         self.assertEqual(
-            etl.job_settings, json.dumps(JobSettings(**self.user_input))
+            etl.job_settings, JobSettings(**self.user_input)
         )
 
     @patch("pathlib.Path.is_file")

--- a/tests/test_mesoscope/test_session.py
+++ b/tests/test_mesoscope/test_session.py
@@ -83,7 +83,9 @@ class TestMesoscope(unittest.TestCase):
         etl = MesoscopeEtl(
             job_settings=job_settings_str,
         )
-        self.assertEqual(etl.job_settings, JobSettings(**self.user_input))
+        self.assertEqual(
+            etl.job_settings, json.dumps(JobSettings(**self.user_input))
+        )
 
     @patch("pathlib.Path.is_file")
     @patch("aind_metadata_mapper.stimulus.camstim.Camstim.__init__")

--- a/tests/test_open_ephys/test_utils/test_pkl_utils.py
+++ b/tests/test_open_ephys/test_utils/test_pkl_utils.py
@@ -61,6 +61,20 @@ class TestPKL(unittest.TestCase):
         with self.assertRaises(KeyError):
             pkl.get_fps(sample_pkl)
 
+    def test_get_stage(self):
+        """
+        Test the get_stage function
+        """
+        # Creating a sample pkl dictionary with a "stage" key
+        sample_pkl = {"stage": "stage1", "other_key": "other_value"}
+
+        # Calling the function with the sample pkl dictionary
+        result = pkl.get_stage(sample_pkl)
+
+        # Asserting that the result is the value associated with the "stage" key
+        self.assertEqual(result, sample_pkl["stage"])
+
+
     def test_get_pre_blank_sec(self):
         """
         Test the get_pre_blank_sec function

--- a/tests/test_open_ephys/test_utils/test_pkl_utils.py
+++ b/tests/test_open_ephys/test_utils/test_pkl_utils.py
@@ -71,7 +71,7 @@ class TestPKL(unittest.TestCase):
         # Calling the function with the sample pkl dictionary
         result = pkl.get_stage(sample_pkl)
 
-        # Asserting that the result is the value associated with the "stage" key
+        # Asserting the value associated with the "stage" key
         self.assertEqual(result, sample_pkl["stage"])
 
     def test_get_pre_blank_sec(self):

--- a/tests/test_open_ephys/test_utils/test_pkl_utils.py
+++ b/tests/test_open_ephys/test_utils/test_pkl_utils.py
@@ -74,7 +74,6 @@ class TestPKL(unittest.TestCase):
         # Asserting that the result is the value associated with the "stage" key
         self.assertEqual(result, sample_pkl["stage"])
 
-
     def test_get_pre_blank_sec(self):
         """
         Test the get_pre_blank_sec function

--- a/tests/test_stimulus/test_camstim.py
+++ b/tests/test_stimulus/test_camstim.py
@@ -1,4 +1,5 @@
 """Test the camstim.py module"""
+
 import unittest
 from datetime import datetime as dt
 from pathlib import Path
@@ -22,6 +23,7 @@ class TestCamstim(unittest.TestCase):
     @patch("aind_metadata_mapper.open_ephys.utils.pkl_utils.load_pkl")
     @patch("aind_metadata_mapper.open_ephys.utils.sync_utils.load_sync")
     @patch("aind_metadata_mapper.open_ephys.utils.pkl_utils.get_fps")
+    @patch("aind_metadata_mapper.open_ephys.utils.pkl_utils.get_stage")
     def setUpClass(
         cls,
         mock_get_fps: MagicMock,

--- a/tests/test_stimulus/test_camstim.py
+++ b/tests/test_stimulus/test_camstim.py
@@ -18,7 +18,6 @@ class TestCamstim(unittest.TestCase):
     @patch("pathlib.Path.rglob")
     @patch("aind_metadata_mapper.stimulus.camstim.Camstim._get_sync_times")
     @patch("aind_metadata_mapper.stimulus.camstim.Camstim.get_session_uuid")
-    @patch("aind_metadata_mapper.stimulus.camstim.Camstim.get_mtrain")
     @patch("aind_metadata_mapper.stimulus.camstim.Camstim._is_behavior")
     @patch("aind_metadata_mapper.open_ephys.utils.pkl_utils.load_pkl")
     @patch("aind_metadata_mapper.open_ephys.utils.sync_utils.load_sync")
@@ -29,7 +28,6 @@ class TestCamstim(unittest.TestCase):
         mock_load_sync: MagicMock,
         mock_load_pkl: MagicMock,
         mock_is_behavior: MagicMock,
-        mock_mtrain: MagicMock,
         mock_session_uuid: MagicMock,
         mock_sync_times: MagicMock,
         mock_rglob: MagicMock,
@@ -48,10 +46,6 @@ class TestCamstim(unittest.TestCase):
             },
         }
         mock_is_behavior.return_value = True
-        mock_mtrain.return_value = {
-            "name": "test_name",
-            "script": "http://example.com/script",
-        }
         mock_session_uuid.return_value = "1234"
         mock_sync_times.return_value = (
             dt(2024, 11, 1, 15, 41, 32, 920082),

--- a/tests/test_stimulus/test_camstim.py
+++ b/tests/test_stimulus/test_camstim.py
@@ -26,6 +26,7 @@ class TestCamstim(unittest.TestCase):
     @patch("aind_metadata_mapper.open_ephys.utils.pkl_utils.get_stage")
     def setUpClass(
         cls,
+        mock_get_stage: MagicMock,
         mock_get_fps: MagicMock,
         mock_load_sync: MagicMock,
         mock_load_pkl: MagicMock,
@@ -53,6 +54,7 @@ class TestCamstim(unittest.TestCase):
             dt(2024, 11, 1, 15, 41, 32, 920082),
             dt(2024, 11, 1, 15, 41, 50, 648629),
         )
+        mock_get_stage.return_value = "stage"
         mock_rglob.return_value = iter([Path("some/path/file.pkl")])
         cls.camstim = Camstim(
             CamstimSettings(


### PR DESCRIPTION
Uses the PKL for stage name and disregards the optional URL field to avoid mtrain query errors.