### PR TITLE
Fixed install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ Repository to contain code that will parse source files into aind-data-schema mo
 ## Installation
 To use the software, in the root directory, run
 ```bash
-pip install -e .[all]
+pip install -e ".[all]"
 ```
 
 It's possible to install just a small subset of dependencies. For example,
 ```bash
-pip install -e .[bergamo]
+pip install -e ".[bergamo]"
 ```
 
 To develop the code, run
 ```bash
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 ## Issues and Discussions


### PR DESCRIPTION
Fix installation commands to work in zsh

Add quotes around pip install arguments to prevent zsh from interpreting square brackets as pattern matching characters. This maintains compatibility across all shells while fixing the installation issue for zsh users (default shell on macOS).

closes #260 