### PR TITLE
Fixed imports in example combined fib+beh session creation script

### DIFF
--- a/scripts/example_create_fiber_and_pav_sessions.py
+++ b/scripts/example_create_fiber_and_pav_sessions.py
@@ -42,8 +42,8 @@ from aind_metadata_mapper.pavlovian_behavior.session import ETL as BehaviorETL
 from aind_metadata_mapper.pavlovian_behavior.models import (
     JobSettings as BehaviorJobSettings,
 )
-from aind_metadata_mapper.fib.session import ETL as FiberETL
-from aind_metadata_mapper.fib.models import JobSettings as FiberJobSettings
+from aind_metadata_mapper.fip.session import FIBEtl as FiberETL
+from aind_metadata_mapper.fip.models import JobSettings as FiberJobSettings
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.units import VolumeUnit
 from aind_metadata_mapper.utils.merge_sessions import merge_sessions

--- a/scripts/example_create_fiber_and_pav_sessions.py
+++ b/scripts/example_create_fiber_and_pav_sessions.py
@@ -18,9 +18,9 @@ Example Usage:
         --fiber-dir data/sample_fiber_data/fib \
         --output-dir data/sample_fiber_data \
         --experimenters "Test User 1" "Test User 2" \
-        --behavior-output "pav_behavior.json" \
-        --fiber-output "fiber_phot.json" \
-        --merged-output "session_combined.json"
+        --behavior-output "session_pavlovian.json" \
+        --fiber-output "session_fib.json" \
+        --merged-output "session.json"
     ```
 
     This will:


### PR DESCRIPTION
I failed to update the imports in the example creation script after a last minute change in #250. This PR fixes that issue. Also updates the example in the docstring to use a better naming convention. 

Verified I can now successfully run:

```bash
% python scripts/example_create_fiber_and_pav_sessions.py \
        --subject-id "000000" \
        --behavior-dir data/sample_fiber_data/behavior \
        --fiber-dir data/sample_fiber_data/fib \
        --output-dir data/sample_fiber_data \
        --experimenters "Test User 1" "Test User 2" \
        --behavior-output "session_pavlovian.json" \
        --fiber-output "session_fib.json" \
        --merged-output "session.json"
 ```
 
 