### PR TITLE
pins wavpack-numcodecs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,8 @@ openephys = [
     "scipy >= 1.11.0",
     "pandas >= 2.2.2",
     "numpy >= 1.26.4",
-    "npc_mvr >= 0.1.6"
+    "npc_mvr >= 0.1.6",
+    "wavpack-numcodecs==0.2.2"
 ]
 
 dynamicrouting = [


### PR DESCRIPTION
Pins wavpack-numcodecs to 0.2.2 (latest version 0.2.3 fails to build with docker image version)

