### PR TITLE
Makes each libary able to independently specify the schema version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,16 @@ dev = [
     "furo",
 ]
 
+schema_v1 = [
+    "aind-data-schema>=1.2.0,<1.3.0",
+]
+
+schema_v2 = [
+    "aind-data-schema>=2.0.0",
+]
+
 fip = [
-    "aind-metadata-mapper[schema]",
+    "aind-metadata-mapper[schema_v1]",
     "tzlocal>=5.3.1",
     "pandas>=2.2.2"
 ]
@@ -48,18 +56,14 @@ all = [
     "aind-metadata-mapper[fip]",
 ]
 
-schema = [
-    "aind-data-schema>=1.2.0,<1.3.0",
-]
-
 bergamo = [
-    "aind-metadata-mapper[schema]",
+    "aind-metadata-mapper[schema_v1]",
     "scanimage-tiff-reader==1.4.1.4",
     "numpy >= 1.26.4",
 ]
 
 bruker = [
-    "aind-metadata-mapper[schema]",
+    "aind-metadata-mapper[schema_v1]",
     "bruker2nifti==1.0.4",
 ]
 
@@ -74,7 +78,7 @@ mesoscope = [
 ]
 
 openephys = [
-    "aind-metadata-mapper[schema]",
+    "aind-metadata-mapper[schema_v1]",
     "h5py >= 3.11.0",
     "hdmf < 4.0.0",
     "npc_ephys >= 0.1.18",
@@ -87,17 +91,17 @@ openephys = [
 ]
 
 dynamicrouting = [
-    "aind-metadata-mapper[schema]",
+    "aind-metadata-mapper[schema_v1]",
     "pyyaml >= 6.0.0",
 ]
 
 u19 = [
-    "aind-metadata-mapper[schema]",
+    "aind-metadata-mapper[schema_v1]",
     "pandas >= 2.2.2",
 ]
 
 smartspim = [
-    "aind-metadata-mapper[schema]",
+    "aind-metadata-mapper[schema_v1]",
     "requests",
 ]
 


### PR DESCRIPTION
Modifies `pyproject.toml` so that each library's aind-data-schema dependency can be defined independently. This will allow us to gradually update libraries to be 2.0 compliant, rather than having to update all at once.

Closes #323