### PR TITLE
Release v0.28.1 (#344)

### DIFF
--- a/src/aind_metadata_mapper/__init__.py
+++ b/src/aind_metadata_mapper/__init__.py
@@ -1,3 +1,3 @@
 """Init package"""
 
-__version__ = "0.28.0"
+__version__ = "0.28.1"

--- a/src/aind_metadata_mapper/mesoscope/models.py
+++ b/src/aind_metadata_mapper/mesoscope/models.py
@@ -48,6 +48,9 @@ class JobSettings(BaseJobSettings):
     optional_output: Optional[Path] = Field(
         default=None, title="Optional output path"
     )
+    lims_project_code: Optional[str] = Field(
+        default="", title="LIMS project code"
+    )
 
     @field_validator("input_source", "behavior_source", "output_directory")
     @classmethod

--- a/src/aind_metadata_mapper/mesoscope/session.py
+++ b/src/aind_metadata_mapper/mesoscope/session.py
@@ -67,6 +67,7 @@ class MesoscopeEtl(GenericEtl[JobSettings]):
             output_directory=camstim_output,
             session_id=self.job_settings.session_id,
             subject_id=self.job_settings.subject_id,
+            lims_project_code=self.job_settings.lims_project_code,
         )
         self.camstim = Camstim(camstim_settings)
 

--- a/src/aind_metadata_mapper/open_ephys/camstim_ephys_session.py
+++ b/src/aind_metadata_mapper/open_ephys/camstim_ephys_session.py
@@ -104,6 +104,9 @@ class CamstimEphysSessionEtl(
         self.stim_table_path = (
             self.session_path / f"{self.folder_name}_stim_epochs.csv"
         )
+        self.vsync_table_path = (
+            self.session_path / f"{self.folder_name}_vsync_epochs.csv"
+        )
         self.sync_path = self.session_path / f"{self.folder_name}.sync"
 
         platform_path = next(
@@ -431,7 +434,7 @@ class CamstimEphysSessionEtl(
 
         opto_params = {}
         for column in opto_table:
-            if column in ("start_time", "stop_time", "stim_name"):
+            if column in ("start_time", "stop_time", "stim_name", "name"):
                 continue
             param_set = set(opto_table[column].dropna())
             opto_params[column] = param_set

--- a/src/aind_metadata_mapper/open_ephys/utils/behavior_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/behavior_utils.py
@@ -812,83 +812,116 @@ def fingerprint_from_stimulus_file(
     fingerprint_name,
 ):
     """
-    Instantiates `fingerprintStimulus` from stimulus file
+    Instantiates fingerprint stimulus epochs from stimulus file.
 
     Parameters
     ----------
-    stimulus_presentations:
-        Table containing previous stimuli
-    stimulus_file
-        BehaviorStimulusFile
-    stimulus_timestamps
-        StimulusTimestamps
+    stimulus_presentations : pd.DataFrame
+        Table containing previous stimuli.
+    stimulus_file : dict
+        BehaviorStimulusFile contents.
+    stimulus_timestamps : np.ndarray
+        Stimulus timestamps aligned to frame indices.
+    fingerprint_name : str
+        Name of the fingerprint stimulus block to extract.
 
     Returns
     -------
-    `fingerprintStimulus`
-        Instantiated fingerprintStimulus
+    pd.DataFrame
+        Table of fingerprint stimulus intervals.
     """
     fingerprint_stim = stimulus_file["items"]["behavior"]["items"][
         fingerprint_name
     ]["static_stimulus"]
+    save_sweep_table = fingerprint_stim.get("save_sweep_table", False)
 
-    # not sure why this was here
-    # n_repeats = fingerprint_stim["runs"]
-
-    # spontaneous + fingerprint indices relative to start of session
+    # Get frame indices relative to full session
     stimulus_session_frame_indices = np.array(
         stimulus_file["items"]["behavior"]["items"][fingerprint_name][
             "frame_indices"
         ]
     )
 
-    # not sure why this was here
-    # movie_length = int(len(fingerprint_stim["sweep_frames"]) / n_repeats)
-
-    # Start index within the spontaneous + fingerprint block
     movie_start_index = sum(
         1 for frame in fingerprint_stim["frame_list"] if frame == -1
     )
-    res = []
-
     sweep_frames = fingerprint_stim["sweep_frames"]
-    sweep_table = [
-        fingerprint_stim["sweep_table"][i]
-        for i in fingerprint_stim["sweep_order"]
-    ]
-    dimnames = fingerprint_stim["dimnames"]
 
     res = []
 
-    for i, stimulus_frame_indices in enumerate(sweep_frames):
-        stimulus_frame_indices = np.array(stimulus_frame_indices).astype(int)
-
-        # Adjust for spontaneous block offset
-        valid_indices = np.clip(
-            stimulus_frame_indices + movie_start_index,
-            0,
-            len(stimulus_session_frame_indices) - 1,
-        )
-
-        start_frame, end_frame = stimulus_session_frame_indices[valid_indices]
-        start_time = stimulus_timestamps[start_frame]
-        stop_time = stimulus_timestamps[
-            min(end_frame + 1, len(stimulus_timestamps) - 1)
+    if save_sweep_table:
+        # Use new logic
+        sweep_table = [
+            fingerprint_stim["sweep_table"][i]
+            for i in fingerprint_stim["sweep_order"]
         ]
+        dimnames = fingerprint_stim["dimnames"]
 
-        stim_row = sweep_table[i]
-        stim_info = dict(zip(dimnames, stim_row))
+        for i, stimulus_frame_indices in enumerate(sweep_frames):
+            stimulus_frame_indices = np.array(stimulus_frame_indices).astype(
+                int
+            )
+            valid_indices = np.clip(
+                stimulus_frame_indices + movie_start_index,
+                0,
+                len(stimulus_session_frame_indices) - 1,
+            )
+            start_frame, end_frame = stimulus_session_frame_indices[
+                valid_indices
+            ]
+            start_time = stimulus_timestamps[start_frame]
+            stop_time = stimulus_timestamps[
+                min(end_frame + 1, len(stimulus_timestamps) - 1)
+            ]
 
-        res.append(
-            {
-                "start_time": start_time,
-                "stop_time": stop_time,
-                "start_frame": start_frame,
-                "end_frame": end_frame,
-                "duration": stop_time - start_time,
-                **stim_info,  # unpack stimulus parameters
-            }
-        )
+            stim_row = sweep_table[i]
+            stim_info = dict(zip(dimnames, stim_row))
+
+            res.append(
+                {
+                    "start_time": start_time,
+                    "stop_time": stop_time,
+                    "start_frame": start_frame,
+                    "end_frame": end_frame,
+                    "duration": stop_time - start_time,
+                    **stim_info,
+                }
+            )
+    else:
+        # Fallback to older logic
+        n_repeats = fingerprint_stim["runs"]
+        movie_length = int(len(sweep_frames) / n_repeats)
+
+        for repeat in range(n_repeats):
+            for frame in range(movie_length):
+                idx = frame + (repeat * movie_length)
+                stimulus_frame_indices = np.array(sweep_frames[idx]).astype(
+                    int
+                )
+                valid_indices = np.clip(
+                    stimulus_frame_indices + movie_start_index,
+                    0,
+                    len(stimulus_session_frame_indices) - 1,
+                )
+                start_frame, end_frame = stimulus_session_frame_indices[
+                    valid_indices
+                ]
+                start_time = stimulus_timestamps[start_frame]
+                stop_time = stimulus_timestamps[
+                    min(end_frame + 1, len(stimulus_timestamps) - 1)
+                ]
+
+                res.append(
+                    {
+                        "movie_frame_index": frame,
+                        "movie_repeat": repeat,
+                        "start_time": start_time,
+                        "stop_time": stop_time,
+                        "start_frame": start_frame,
+                        "end_frame": end_frame,
+                        "duration": stop_time - start_time,
+                    }
+                )
 
     table = pd.DataFrame(res)
 
@@ -1152,8 +1185,72 @@ def from_stimulus_file(
 
     df.drop(columns=["stim_block"], inplace=True, errors="ignore")
     df = df.drop(columns=["start_frame", "end_frame"], errors="ignore")
+    # organize rows with the same start/stop time alphabetically by stim_name
+    # For example, if there are two stimuli with the same start and stop time,
+    # one with stim_name "A" and the other with "B", the row with
+    # "A" will come before "B"
+    df = reorder_by_stim_in_temporal_blocks(
+        df=df,
+    )
 
     return (df, column_list)
+
+
+def reorder_by_stim_in_temporal_blocks(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Reorders the stimulus presentations DataFrame by grouping consecutive
+    blocks of stimuli with the same start and stop times, and then ordering
+    the rows within each block by their `stim_name`.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing stimulus presentations with columns:
+        - `start_time`: Start time of the stimulus presentation
+        - `stop_time`: Stop time of the stimulus presentation
+        - `stim_name`: Name of the stimulus
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with rows ordered by temporal blocks and `stim_name`.
+    """
+    df = df.sort_values(by=["start_time", "stop_time"]).reset_index(drop=True)
+
+    # Step 1: Create temporal blocks
+    grouped = df.groupby(["start_time", "stop_time"], sort=False)
+
+    blocks = []
+    for _, group in grouped:
+        blocks.append(group.reset_index(drop=True))
+
+    # Step 2: Process blocks to form chunks of consecutive blocks
+    # with same stim_name set
+    chunks = []
+    current_chunk = [blocks[0]]
+    current_stims = set(blocks[0]["stim_name"])
+
+    for block in blocks[1:]:
+        block_stims = set(block["stim_name"])
+        if block_stims == current_stims:
+            current_chunk.append(block)
+        else:
+            chunks.append(current_chunk)
+            current_chunk = [block]
+            current_stims = block_stims
+    chunks.append(current_chunk)  # Add the last one
+
+    # Step 3: Within each chunk, order by stim_name
+    output_blocks = []
+    for chunk in chunks:
+        combined = pd.concat(chunk, ignore_index=True)
+        for stimulus in combined["stim_name"].unique():
+            stim_rows = combined[combined["stim_name"] == stimulus]
+            output_blocks.append(stim_rows)
+
+    # Step 4: Combine all blocks into final result
+    final_df = pd.concat(output_blocks, ignore_index=True)
+    return final_df
 
 
 def get_is_image_novel(

--- a/src/aind_metadata_mapper/stimulus/camstim.py
+++ b/src/aind_metadata_mapper/stimulus/camstim.py
@@ -36,6 +36,7 @@ class CamstimSettings(BaseModel):
     output_directory: Optional[Path]
     session_id: str
     subject_id: str
+    lims_project_code: Optional[str] = ""
 
 
 class Camstim:
@@ -287,6 +288,33 @@ class Camstim:
                 elif param_set:
                     current_epoch[3][column] = param_set
 
+    def extract_whole_session_epoch(
+        self, stim_table: pd.DataFrame
+    ) -> list[list[str, int, int, dict, set]]:
+        """
+        Extracts a single epoch covering the entire session from the
+        stimulus table. Returns a list containing one epoch with the first
+        stim_name, the first start_time, the last stop_time, an empty dict,
+        and a set of template names.
+        """
+        row = stim_table.iloc[0]
+        single_epoch = [
+            stim_table["stim_name"].iloc[0],
+            stim_table["start_time"].iloc[0],
+            stim_table["stop_time"].iloc[-1],
+            {},
+            set(),
+        ]
+        self._summarize_epoch_params(stim_table, single_epoch, 0, -1)
+        stim_name = row.get("stim_name", "") or ""
+        image_set = row.get("image_set", "")
+        if pd.notnull(image_set):
+            stim_name = image_set
+
+        if "image" in stim_name.lower() or "movie" in stim_name.lower():
+            single_epoch[4].add(row["stim_name"])
+        return [single_epoch]
+
     def extract_stim_epochs(
         self, stim_table: pd.DataFrame
     ) -> list[list[str, int, int, dict, set]]:
@@ -300,12 +328,19 @@ class Camstim:
         stim_name, stim_type, or frame) are listed as parameters, and the set
         of values for that column are listed as parameter values.
         """
-        epochs = []
+        if type(self) is Camstim:
+            if self.camstim_settings.lims_project_code == "U01BFCT":
+                return self.extract_whole_session_epoch(stim_table)
 
+        epochs = []
         current_epoch = [None, 0.0, 0.0, {}, set()]
+        # Initialize the first epoch with the first row of the stim table
         epoch_start_idx = 0
         for current_idx, row in stim_table.iterrows():
-            if row["stim_name"] == "spontaneous":
+            if (
+                row["stim_name"] == "spontaneous"
+                or row["start_time"] == current_epoch[1]
+            ):
                 continue
             if row["stim_name"] != current_epoch[0]:
                 self._summarize_epoch_params(
@@ -330,7 +365,46 @@ class Camstim:
 
             if "image" in stim_name.lower() or "movie" in stim_name.lower():
                 current_epoch[4].add(row["stim_name"])
+
+        # append final epoch after iteration
+        self._summarize_epoch_params(
+            stim_table, current_epoch, epoch_start_idx, current_idx
+        )
+        epochs.append(current_epoch)
+        # slice off the default starting epoch
         return epochs[1:]
+
+    def _summarize_params(self, rows: pd.DataFrame) -> dict:
+        """
+        Summarizes the parameters from the stimulus epochs table.
+
+        Parameters
+        ----------
+        rows : pd.DataFrame
+            DataFrame containing the rows of the stimulus epochs table.
+
+        Returns
+        -------
+        dict
+            A dictionary where keys are parameter names and values are
+            either a single value or a list of unique values for that
+            parameter across the rows.
+        """
+        ignore_columns = {"start_time",
+                          "stop_time",
+                          "stim_name",
+                          "stim_type",
+                          "frame",
+                          "time_key"}
+        params = {}
+        for col in rows.columns:
+            if col not in ignore_columns:
+                unique_vals = rows[col].dropna().unique()
+                if len(unique_vals) == 1:
+                    params[col] = unique_vals[0]
+                elif len(unique_vals) > 1:
+                    params[col] = list(unique_vals)
+        return params
 
     def epochs_from_stim_table(self) -> list[StimulusEpoch]:
         """

--- a/tests/test_open_ephys/test_session.py
+++ b/tests/test_open_ephys/test_session.py
@@ -2,284 +2,138 @@
 
 # TODO: implement tests once np package issues are resolved
 
-# import csv
-# import json
-# import os
-# import unittest
-# import zoneinfo
-# from pathlib import Path
-# from xml.dom import minidom
-#
-# from aind_data_schema.core.session import Session
-#
-# from aind_metadata_mapper.open_ephys.camstim_ephys_session import (
-#     CamstimEphysSession,
-# )
-# from aind_metadata_mapper.open_ephys.session import EphysEtl
-#
-# RESOURCES_DIR = (
-#     Path(os.path.dirname(os.path.realpath(__file__)))
-#     / ".."
-#     / "resources"
-#     / "open_ephys"
-# )
-#
-# EXAMPLE_STAGE_LOGS = [
-#     RESOURCES_DIR / "newscale_main.csv",
-#     RESOURCES_DIR / "newscale_surface_finding.csv",
-# ]
-# EXAMPLE_OPENEPHYS_LOGS = [
-#     RESOURCES_DIR / "settings_main.xml",
-#     RESOURCES_DIR / "settings_surface_finding.xml",
-# ]
-#
-# EXPECTED_SESSION = RESOURCES_DIR / "ephys_session.json"
-#
-# EXPECTED_CAMSTIM_JSON = RESOURCES_DIR / "camstim_ephys_session.json"
-#
-#
-# class TestEphysSession(unittest.TestCase):
-#     """Test methods in open_ephys session module."""
-#
-#     maxDiff = None  # show full diff without truncation
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         """Load record object and user settings before running tests."""
-#         # TODO: Add visual stimulus
-#         cls.experiment_data = {
-#             "experimenter_full_name": ["Al Dente"],
-#             "subject_id": "699889",
-#             "session_type": "Receptive field mapping",
-#             "iacuc_protocol": "2109",
-#             "rig_id": "323_EPHYS2-RF_2024-01-18_01",
-#             "animal_weight_prior": None,
-#             "animal_weight_post": None,
-#             "calibrations": [],
-#             "maintenance": [],
-#             "camera_names": [],
-#             "stick_microscopes": [
-#                 {
-#                     "assembly_name": "20516338",
-#                     "arc_angle": -180.0,
-#                     "module_angle": -180.0,
-#                     "angle_unit": "degrees",
-#                     "notes": "Did not record arc or module angles, "
-#                     "did not calibrate",
-#                 },
-#                 {
-#                     "assembly_name": "22437106",
-#                     "arc_angle": -180.0,
-#                     "module_angle": -180.0,
-#                     "angle_unit": "degrees",
-#                     "notes": "Did not record arc or module angles, "
-#                     "did not calibrate",
-#                 },
-#                 {
-#                     "assembly_name": "22437107",
-#                     "arc_angle": -180.0,
-#                     "module_angle": -180.0,
-#                     "angle_unit": "degrees",
-#                     "notes": "Did not record arc or module angles, "
-#                     "did not calibrate",
-#                 },
-#                 {
-#                     "assembly_name": "22438379",
-#                     "arc_angle": -180.0,
-#                     "module_angle": -180.0,
-#                     "angle_unit": "degrees",
-#                     "notes": "Did not record arc or module angles, "
-#                     "did not calibrate",
-#                 },
-#             ],
-#             "daqs": "Basestation",
-#             # data streams have to be in same
-#             # order as setting.xml's and newscale.csv's
-#             "data_streams": [
-#                 {
-#                     "ephys_module_46121": {
-#                         "arc_angle": 5.3,
-#                         "module_angle": -27.1,
-#                         "angle_unit": "degrees",
-#                         "coordinate_transform": "behavior/"
-#                         "calibration_info_np2_2024_01_17T15_04_00.npy",
-#                         "calibration_date": "2024-01-17T15:04:00+00:00",
-#                         "notes": "Easy insertion. Recorded 8 minutes, "
-#                         "serially, so separate from prior insertion.",
-#                         "primary_targeted_structure": "AntComMid",
-#                         "targeted_ccf_coordinates": [
-#                             {
-#                                 "ml": 5700.0,
-#                                 "ap": 5160.0,
-#                                 "dv": 5260.0,
-#                                 "unit": "micrometer",
-#                                 "ccf_version": "CCFv3",
-#                             }
-#                         ],
-#                     },
-#                     "ephys_module_46118": {
-#                         "arc_angle": 14,
-#                         "module_angle": 20,
-#                         "angle_unit": "degrees",
-#                         "coordinate_transform": "behavior/"
-#                         "calibration_info_np2_2024_01_17T15_04_00.npy",
-#                         "calibration_date": "2024-01-17T15:04:00+00:00",
-#                         "notes": "Easy insertion. Recorded 8 minutes, "
-#                         "serially, so separate from prior insertion.",
-#                         "primary_targeted_structure": "VISp",
-#                         "targeted_ccf_coordinates": [
-#                             {
-#                                 "ml": 5700.0,
-#                                 "ap": 5160.0,
-#                                 "dv": 5260.0,
-#                                 "unit": "micrometer",
-#                                 "ccf_version": "CCFv3",
-#                             }
-#                         ],
-#                     },
-#                     "mouse_platform_name": "Running Wheel",
-#                     "active_mouse_platform": False,
-#                     "notes": "699889_2024-01-18_12-12-04",
-#                 },
-#                 {
-#                     "ephys_module_46121": {
-#                         "arc_angle": 5.3,
-#                         "module_angle": -27.1,
-#                         "angle_unit": "degrees",
-#                         "coordinate_transform": "behavior/"
-#                         "calibration_info_np2_2024_01_17T15_04_00.npy",
-#                         "calibration_date": "2024-01-17T15:04:00+00:00",
-#                         "notes": "Easy insertion. Recorded 8 minutes, "
-#                         "serially, so separate from prior insertion.",
-#                         "primary_targeted_structure": "AntComMid",
-#                         "targeted_ccf_coordinates": [
-#                             {
-#                                 "ml": 5700.0,
-#                                 "ap": 5160.0,
-#                                 "dv": 5260.0,
-#                                 "unit": "micrometer",
-#                                 "ccf_version": "CCFv3",
-#                             }
-#                         ],
-#                     },
-#                     "ephys_module_46118": {
-#                         "arc_angle": 14,
-#                         "module_angle": 20,
-#                         "angle_unit": "degrees",
-#                         "coordinate_transform": "behavior/"
-#                         "calibration_info_np2_2024_01_17T15_04_00.npy",
-#                         "calibration_date": "2024-01-17T15:04:00+00:00",
-#                         "notes": "Easy insertion. Recorded 8 minutes, "
-#                         "serially, so separate from prior insertion.",
-#                         "primary_targeted_structure": "VISp",
-#                         "targeted_ccf_coordinates": [
-#                             {
-#                                 "ml": 5700.0,
-#                                 "ap": 5160.0,
-#                                 "dv": 5260.0,
-#                                 "unit": "micrometer",
-#                                 "ccf_version": "CCFv3",
-#                             }
-#                         ],
-#                     },
-#                     "mouse_platform_name": "Running Wheel",
-#                     "active_mouse_platform": False,
-#                     "notes": "699889_2024-01-18_12-24-55; Surface Finding",
-#                 },
-#             ],
-#         }
-#
-#         stage_logs = []
-#         openephys_logs = []
-#         for stage, openephys in zip(
-#             EXAMPLE_STAGE_LOGS, EXAMPLE_OPENEPHYS_LOGS
-#         ):
-#             with open(stage, "r") as f:
-#                 stage_logs.append([row for row in csv.reader(f)])
-#             with open(openephys, "r") as f:
-#                 openephys_logs.append(minidom.parse(f))
-#
-#         with open(EXPECTED_SESSION, "r") as f:
-#             expected_session = Session(**json.load(f))
-#
-#         cls.stage_logs = stage_logs
-#         cls.openephys_logs = openephys_logs
-#         cls.expected_session = expected_session
-#
-#     def test_extract(self):
-#         """Tests that the stage and openophys logs and experiment
-#         data is extracted correctly"""
-#
-#         etl_job1 = EphysEtl(
-#             output_directory=RESOURCES_DIR,
-#             stage_logs=self.stage_logs,
-#             openephys_logs=self.openephys_logs,
-#             experiment_data=self.experiment_data,
-#         )
-#         parsed_info = etl_job1._extract()
-#         self.assertEqual(self.stage_logs, parsed_info.stage_logs)
-#         self.assertEqual(self.openephys_logs, parsed_info.openephys_logs)
-#         self.assertEqual(self.experiment_data, parsed_info.experiment_data)
-#
-#     def test_transform(self):
-#         """Tests that the teensy response maps correctly to ophys session."""
-#
-#         etl_job1 = EphysEtl(
-#             output_directory=RESOURCES_DIR,
-#             stage_logs=self.stage_logs,
-#             openephys_logs=self.openephys_logs,
-#             experiment_data=self.experiment_data,
-#         )
-#         parsed_info = etl_job1._extract()
-#         actual_session = etl_job1._transform(parsed_info)
-#         actual_session.session_start_time = (
-#             actual_session.session_start_time.replace(
-#                 tzinfo=zoneinfo.ZoneInfo("UTC")
-#             )
-#         )
-#         actual_session.session_end_time = (
-#             actual_session.session_end_time.replace(
-#                 tzinfo=zoneinfo.ZoneInfo("UTC")
-#             )
-#         )
-#         for stream in actual_session.data_streams:
-#             stream.stream_start_time = stream.stream_start_time.replace(
-#                 tzinfo=zoneinfo.ZoneInfo("UTC")
-#             )
-#             stream.stream_end_time = stream.stream_end_time.replace(
-#                 tzinfo=zoneinfo.ZoneInfo("UTC")
-#             )
-#         self.assertEqual(
-#             self.expected_session.model_dump(),
-#             actual_session.model_dump(),
-#         )
-#
-#
-# class TestCamstimEphysSession(unittest.TestCase):
-#     """Test methods in camstim ephys session module."""
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         """
-#         Load expected json
-#         """
-#         cls.expected_json = json.load(EXPECTED_CAMSTIM_JSON)
-#
-#     def test_generate_json(cls):
-#         """
-#         Attempt to generate a temporal barcoding json
-#         """
-#         json_settings = {
-#             "description": "OpenScope's Temporal Barcoding project",
-#             "iacuc_protocol": "2117",
-#             "session_type": "",
-#         }
-#         camstim_session_mapper = CamstimEphysSession(
-#             "1315994569", json_settings
-#         )
-#         output_session_json = camstim_session_mapper.generate_session_json()
-#         cls.assertEqual(cls.expected_json, output_session_json)
-#
-#
-# if __name__ == "__main__":
-#     unittest.main()
+import shutil
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+import pandas as pd
+
+from aind_metadata_mapper.open_ephys.camstim_ephys_session import (
+    CamstimEphysSessionEtl
+)
+from aind_metadata_mapper.open_ephys.models import (
+    JobSettings as CamstimEphysJobSettings
+)
+
+RESOURCES_DIR = (
+    Path(__file__).parent.parent / "resources" / "open_ephys"
+)
+
+EXAMPLE_STAGE_LOGS = [
+    RESOURCES_DIR / "newscale_main.csv",
+    RESOURCES_DIR / "newscale_surface_finding.csv",
+]
+EXAMPLE_OPENEPHYS_LOGS = [
+    RESOURCES_DIR / "settings_main.xml",
+    RESOURCES_DIR / "settings_surface_finding.xml",
+]
+
+EXPECTED_SESSION = RESOURCES_DIR / "ephys_session.json"
+
+EXPECTED_CAMSTIM_JSON = RESOURCES_DIR / "camstim_ephys_session.json"
+
+
+class TestCamstimEphysSessionEtl(unittest.TestCase):
+    """Test methods in camstim ephys session module."""
+
+    @patch('aind_metadata_mapper.open_ephys.utils.pkl_utils.get_stage')
+    @patch('aind_metadata_mapper.open_ephys.utils.pkl_utils.get_fps')
+    @patch('aind_metadata_mapper.open_ephys.utils.sync_utils.get_stop_time')
+    @patch('aind_metadata_mapper.open_ephys.utils.sync_utils.get_start_time')
+    @patch('aind_metadata_mapper.open_ephys.utils.sync_utils.load_sync')
+    @patch('aind_metadata_mapper.open_ephys.utils.pkl_utils.load_pkl')
+    @patch('pandas.read_csv')
+    @patch('json.loads')
+    @patch('pathlib.Path.read_text')
+    @patch('pathlib.Path.glob')
+    @patch('pathlib.Path.exists')
+    @patch(
+        'aind_metadata_mapper.open_ephys.camstim_ephys_session.'
+        'get_single_oebin_path'
+    )
+    def setUp(
+        self,
+        mock_oebin,
+        mock_exists,
+        mock_glob,
+        mock_read_text,
+        mock_json_loads,
+        mock_read_csv,
+        mock_load_pkl,
+        mock_load_sync,
+        mock_start_time,
+        mock_stop_time,
+        mock_fps,
+        mock_stage,
+    ):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+
+        # Configure all mocks
+        mock_oebin.return_value = Path(self.temp_dir) / "fake.oebin"
+        mock_exists.return_value = True
+        # Return an iterator instead of a list
+        mock_glob.return_value = iter([Path(self.temp_dir) / "platform.json"])
+        mock_read_text.return_value = '{"project": "test_project"}'
+        mock_json_loads.return_value = {
+            "project": "test_project",
+            "operatorID": "test.operator",
+            "rig_id": "test_rig",
+            "InsertionNotes": {}
+        }
+
+        # Mock pandas.read_csv to return a DataFrame with all expected columns
+        mock_read_csv.return_value = pd.DataFrame({
+            'Start': [0.0, 10.0, 20.0],
+            'End': [5.0, 15.0, 25.0],
+            'start_time': [0.0, 10.0, 20.0],
+            'stop_time': [5.0, 15.0, 25.0],
+            'stim_name': ['stim1', 'stim2', 'stim3']
+        })
+
+        mock_load_pkl.return_value = {
+            "fps": 60,
+            "stage": "test_stage",
+            "session_uuid": "test-session-uuid-123"
+        }
+        mock_load_sync.return_value = None
+        # Return datetime objects instead of floats
+        mock_start_time.return_value = datetime(2023, 1, 1, 10, 0, 0)
+        mock_stop_time.return_value = datetime(2023, 1, 1, 12, 0, 0)
+        mock_fps.return_value = 60
+        mock_stage.return_value = "test_stage"
+
+        self.job_settings = CamstimEphysJobSettings(
+            session_type="test_session",
+            project_name="test_project",
+            iacuc_protocol="test_protocol",
+            description="test_description",
+            mtrain_server="test_server",
+            session_id="test_session_id",
+            input_source=self.temp_dir
+        )
+        self.etl = CamstimEphysSessionEtl(job_settings=self.job_settings)
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_init(self):
+        """Test initialization."""
+        self.assertIsInstance(self.etl, CamstimEphysSessionEtl)
+
+    def test_has_job_settings(self):
+        """Test that job_settings attribute exists."""
+        self.assertTrue(hasattr(self.etl, 'job_settings'))
+
+    def test_basic_attributes_exist(self):
+        """Test that basic attributes exist."""
+        attrs = ['job_settings', 'recording_dir']
+        for attr in attrs:
+            self.assertTrue(hasattr(self.etl, attr))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_open_ephys/test_utils/test_behavior_utils.py
+++ b/tests/test_open_ephys/test_utils/test_behavior_utils.py
@@ -712,6 +712,7 @@ class TestBehaviorUtils(unittest.TestCase):
                                     "movie_frame_index",
                                     "movie_repeat",
                                 ],
+                                "save_sweep_table": True,
                             },
                             "frame_indices": [0, 1, 2, 3, 4, 5],
                         }
@@ -729,6 +730,7 @@ class TestBehaviorUtils(unittest.TestCase):
             "fingerprint",
         )
 
+        print(result)
         # Define expected output based on the provided mock data
         expected_columns = [
             "movie_frame_index",

--- a/tests/test_open_ephys/test_utils/test_stim_utils.py
+++ b/tests/test_open_ephys/test_utils/test_stim_utils.py
@@ -272,22 +272,25 @@ class TestStimUtils(unittest.TestCase):
         stim_table_1 = pd.DataFrame(
             {
                 "start_time": [10, 20],
-                "end_time": [15, 25],
+                "stop_time": [15, 25],
                 "stim_param": ["a", "b"],
+                "stim_name": ["stim1", "stim1"],
             }
         )
         stim_table_2 = pd.DataFrame(
             {
                 "start_time": [30, 40],
-                "end_time": [35, 45],
+                "stop_time": [35, 45],
                 "stim_param": ["c", "d"],
+                "stim_name": ["stim2", "stim2"],
             }
         )
         stim_table_3 = pd.DataFrame(
             {
                 "start_time": [5, 50],
-                "end_time": [10, 55],
+                "stop_time": [10, 55],
                 "stim_param": ["e", "f"],
+                "stim_name": ["spontaneous", "spontaneous"],
             }
         )
 
@@ -295,9 +298,17 @@ class TestStimUtils(unittest.TestCase):
         expected_stim_table_full = pd.DataFrame(
             {
                 "start_time": [5, 10, 20, 30, 40, 50],
-                "end_time": [10, 15, 25, 35, 45, 55],
+                "stop_time": [10, 15, 25, 35, 45, 55],
                 "stim_param": ["e", "a", "b", "c", "d", "f"],
                 "stim_index": [pd.NA, 0.0, 0.0, 1.0, 1.0, pd.NA],
+                "stim_name": [
+                    "spontaneous",
+                    "stim1",
+                    "stim1",
+                    "stim2",
+                    "stim2",
+                    "spontaneous",
+                ],
                 "stim_block": [0, 0, 0, 1, 1, 2],
             }
         )
@@ -326,19 +337,19 @@ class TestStimUtils(unittest.TestCase):
             mock_stimulus_tabler,
             mock_spontaneous_activity_tabler,
         )
-        self.assertEquals(
+        self.assertEqual(
             result_stim_table_full["start_time"].all(),
             expected_stim_table_full["start_time"].all(),
         )
-        self.assertEquals(
-            result_stim_table_full["end_time"].all(),
-            expected_stim_table_full["end_time"].all(),
+        self.assertEqual(
+            result_stim_table_full["stop_time"].all(),
+            expected_stim_table_full["stop_time"].all(),
         )
-        self.assertEquals(
+        self.assertEqual(
             result_stim_table_full["stim_param"].all(),
             expected_stim_table_full["stim_param"].all(),
         )
-        self.assertEquals(
+        self.assertEqual(
             result_stim_table_full["stim_block"].all(),
             expected_stim_table_full["stim_block"].all(),
         )

--- a/tests/test_smartspim/test_acquisition.py
+++ b/tests/test_smartspim/test_acquisition.py
@@ -94,8 +94,8 @@ class TestSmartspimETL(unittest.TestCase):
         }
 
         result = (
-            self.example_smartspim_etl_success.
-            _extract_metadata_from_microscope_files()
+            self.example_smartspim_etl_success
+                ._extract_metadata_from_microscope_files()
         )
 
         expected_result = {
@@ -286,8 +286,8 @@ class TestSmartspimETL(unittest.TestCase):
         }
 
         test_extracted = (
-            self.example_smartspim_etl_fail_mouseid.
-            _extract_metadata_from_microscope_files()
+            self.example_smartspim_etl_fail_mouseid
+                ._extract_metadata_from_microscope_files()
         )
 
         with self.assertRaises(ValueError):
@@ -371,9 +371,7 @@ class TestSmartspimETL(unittest.TestCase):
         mock_write.return_value = None
         job_settings = self.example_job_settings_success.model_copy(deep=True)
         job_settings.slims_datetime = "2024-10-10_10-10-10"
-        etl = SmartspimETL(
-            job_settings=job_settings
-        )
+        etl = SmartspimETL(job_settings=job_settings)
         response = etl.run_job()
         mock_write.assert_called_once()
         self.assertEqual(200, response.status_code)

--- a/tests/test_stimulus/test_camstim.py
+++ b/tests/test_stimulus/test_camstim.py
@@ -314,6 +314,25 @@ class TestCamstim(unittest.TestCase):
         expected_result = pd.DataFrame({"a": [1, 2, 3]})
         pd.testing.assert_frame_equal(result, expected_result)
 
+    def test_extract_whole_session_epoch(self):
+        """
+        Test that extract_whole_session_epoch returns the correct start and
+        stop times for a mock stim_table DataFrame.
+        """
+        # Create a mock stim_table DataFrame
+        stim_table = pd.DataFrame(
+            {
+                "start_time": [0.0, 10.0, 20.0],
+                "stop_time": [5.0, 15.0, 25.0],
+            }
+        )
+        camstim = self.camstim
+        # Call the method
+        result = camstim.extract_whole_session_epoch(stim_table)
+        # Check that the result is as expected (tuple of (start, stop))
+        self.assertEqual(result[0], stim_table.start_time.iloc[0])
+        self.assertEqual(result[1], stim_table.stop_time.iloc[-1])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* add final epoch to table

* handle overlapping simultaneous stim epochs

* feat: create session object with lims project code

* feat: add lims project code to jobsettings

* use lims project id to determine whether to summarize all stim in one whole session epoch

* add docstrings

* update order of behavior table

* update order of stim table

* update epoch check for stim blocks

* add case for when sweep table isn't saved

* update sorting function and revert to carter's epochs

* fix test

* add vsync table path (because camstim class expects one to exist in child objects

* exclude name from opto epoch params

* only check camstim project code if it is not an ecephys camstim object


* Release v0.28.1

---------