### PR TITLE
feat: fetch subject and procedures metadata from metadata service v2 endpoints

### DIFF
--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -73,11 +73,12 @@ class GatherMetadataJob:
                 f"{self.settings.metadata_service_url}"
             )
             response = requests.get(
-                f"{self.settings.metadata_service_url}/subject/{subject_id}"
+                f"{self.settings.metadata_service_url}"
+                f"/api/v2/subject/{subject_id}"
             )
             if response.status_code not in ["200", "406"]:
                 response.raise_for_status()
-            contents = response.json()["data"]
+            contents = response.json()
         else:
             logging.debug(f"Using existing {file_name}.")
             contents = self._get_file_from_user_defined_directory(

--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -76,7 +76,7 @@ class GatherMetadataJob:
                 f"{self.settings.metadata_service_url}"
                 f"/api/v2/subject/{subject_id}"
             )
-            if response.status_code not in ["200", "406"]:
+            if response.status_code not in [200, 400]:
                 response.raise_for_status()
             contents = response.json()
         else:

--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -5,6 +5,7 @@ import logging
 import os
 
 import requests
+from aind_data_schema.core.procedures import Procedures
 from aind_data_schema.core.subject import Subject
 
 from aind_metadata_mapper.models import JobSettings
@@ -86,11 +87,37 @@ class GatherMetadataJob:
             )
         return contents
 
+    def get_procedures(self) -> dict:
+        """Get procedures metadata"""
+        logging.info("Gathering procedures metadata.")
+        file_name = Procedures.default_filename()
+        subject_id = self.settings.subject_id
+        if not self._does_file_exist_in_user_defined_dir(file_name=file_name):
+            logging.debug(
+                f"No procedures file found in directory. Downloading "
+                f"{self.settings.subject_id} from "
+                f"{self.settings.metadata_service_url}"
+            )
+            response = requests.get(
+                f"{self.settings.metadata_service_url}"
+                f"/api/v2/procedures/{subject_id}"
+            )
+            if response.status_code not in [200, 400]:
+                response.raise_for_status()
+            contents = response.json()
+        else:
+            logging.debug(f"Using existing {file_name}.")
+            contents = self._get_file_from_user_defined_directory(
+                file_name=file_name
+            )
+        return contents
+
     def run_job(self) -> None:
         """Run job"""
         logging.info("Starting run_job")
         core_metadata = dict()
         core_metadata[Subject.default_filename()] = self.get_subject()
+        core_metadata[Procedures.default_filename()] = self.get_procedures()
 
         for k, v in core_metadata.items():
             logging.debug(f"Writing {k} file")

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -1,4 +1,5 @@
 """Tests gather_metadata module"""
+
 import json
 import os
 import unittest
@@ -23,7 +24,7 @@ class TestGatherMetadataJob(unittest.TestCase):
         mock_fail_response.status_code = 500
         mock_success_response = Response()
         mock_success_response.status_code = 200
-        body = json.dumps({"data": {"example": "only"}})
+        body = json.dumps({"example": "only"})
         mock_success_response._content = body.encode("utf-8")
         example_job_settings = JobSettings(metadata_dir=str(TEST_DIR))
         cls.success_response = mock_success_response


### PR DESCRIPTION
closes #350 

- uses metadata service `/api/v2/subject/{subject_id}` endpoint for subject metadata
- uses `/api/v2/procedures/{subject_id}` endpoint for procedures metadata
- uses correct response status codes (int 400 instead of str 406)