### PR TITLE
Fix json dump datetime bug and add test

### DIFF
--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -356,7 +356,7 @@ class GatherMetadataJob:
         for model in model_objs[1:]:
             merged_model = merged_model + model
 
-        return merged_model.model_dump()
+        return merged_model.model_dump(mode="json")
 
     def get_instrument(self) -> Optional[dict]:
         """Get instrument metadata"""


### PR DESCRIPTION
Fixes an error with datetime objects when merging acquisitions in `gather_metadata.py`. Adds a test to verify correct behavior.

Closes #411 