### PR TITLE
Add protocol lookup

### DIFF
--- a/src/aind_metadata_mapper/utils.py
+++ b/src/aind_metadata_mapper/utils.py
@@ -19,6 +19,60 @@ INSTRUMENT_BASE_URL = "http://aind-metadata-service/api/v2/instrument"
 PROCEDURES_BASE_URL = "http://aind-metadata-service/api/v2/procedures"
 
 
+def get_ethics_id(subject_id: str) -> Optional[str]:
+    """Get ethics review ID for a subject ID.
+
+    Currently uses a hard-coded mapping for VR Foraging mice.
+    TODO: Replace with API call to Dataverse when table exists.
+
+    Parameters
+    ----------
+    subject_id : str
+        The subject ID to look up.
+
+    Returns
+    -------
+    Optional[str]
+        Ethics review ID string (e.g., "2414") if found, None otherwise.
+    """
+    # Hard-coded mapping of VR Foraging subject IDs to ethics review ID
+    # TODO: Replace with API call to Dataverse when table exists
+    vr_foraging_ethics_map = {
+        "788731": "2414",
+        "789907": "2414",
+        "795133": "2414",
+        "798279": "2414",
+        "804434": "2414",
+        "807086": "2414",
+        "808619": "2414",
+        "808729": "2414",
+        "810750": "2414",
+        "811021": "2414",
+        "815102": "2414",
+        "815104": "2414",
+        "828417": "2414",
+        "828420": "2414",
+        "828422": "2414",
+        "828425": "2414",
+        "789903": "2414",
+        "789917": "2414",
+        "795556": "2414",
+        "804430": "2414",
+        "806527": "2414",
+        "807093": "2414",
+        "808728": "2414",
+        "810351": "2414",
+        "810761": "2414",
+        "811026": "2414",
+        "815103": "2414",
+        "828416": "2414",
+        "828418": "2414",
+        "828421": "2414",
+        "828423": "2414",
+    }
+    return vr_foraging_ethics_map.get(subject_id)
+
+
 def ensure_timezone(dt):
     """Ensure datetime has timezone info using system local timezone.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -316,6 +316,11 @@ class TestUtils(unittest.TestCase):
         # Should return a list (may be empty if protocols.yaml doesn't have fip, but should not error)
         self.assertIsInstance(result, list)
 
+    def test_get_ethics_id_not_found(self):
+        """Test that get_ethics_id returns None for subject IDs not in the mapping."""
+        result = utils.get_ethics_id("test")
+        self.assertIsNone(result)
+
 
 class TestPromptFunctions(unittest.TestCase):
     """Tests for prompt utility functions."""


### PR DESCRIPTION
Adds protocol_id (aka ethics_review_id) during gather metadata process. This allows us to inject ethics_review_id even if we have been handed 'complete' metadata that lacks it, without requiring us to build a dedicated mapper (i.e. if a group has opted out of the extractor/mapper pattern). If a user is passing the ethics_review_id, this would simply verify that it matches the result from the table (if available).

For now this hardcodes a mapping for known VR Foraging mice. We can replace this with a call to DataVerse when that table is available. This should be a pre-condition for merging this PR.

Alternatively, we can wait to add this until we have access to the dataverse table since it seems like this is coming relatively quickly.