### PR TITLE
fix: catch all exceptions including non-validation errors

### DIFF
--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -512,14 +512,15 @@ class GatherMetadataJob:
                 logging.info("Metadata validation successful!")
                 return metadata
 
-            except ValidationError as e:
+            except Exception as e:
                 logging.warning(f"Metadata validation failed: {e}")
                 logging.info("Creating metadata object with validation bypass")
 
                 # Display validation errors to user
-                logging.warning("Validation Errors Found:")
-                for error in e.errors():
-                    logging.warning(f"  - {error['loc']}: {error['msg']}")
+                if isinstance(e, ValidationError):
+                    logging.warning("Validation Errors Found:")
+                    for error in e.errors():
+                        logging.warning(f"  - {error['loc']}: {error['msg']}")
 
                 # Use create_metadata_json to construct metadata object
                 metadata = create_metadata_json(


### PR DESCRIPTION
This PR catches all exceptions instead of only ValidationError, ensuring that the `raise_if_invalid` flag applies correctly so situations where an internal validation error in a subclass of `Metadata` triggers a different kind of exception are handled.