### PR TITLE
Fix calculation of fps in pkl_utils.py

### DIFF
--- a/src/aind_metadata_mapper/open_ephys/utils/pkl_utils.py
+++ b/src/aind_metadata_mapper/open_ephys/utils/pkl_utils.py
@@ -70,7 +70,7 @@ def get_fps(pkl):
     """
     if not pkl.get("fps"):
         fps = round(
-            1 / np.mean(pkl["items"]["behavior"]["intervalsms"]) * 0.001, 2
+            1 / (np.mean(pkl["items"]["behavior"]["intervalsms"]) * 0.001), 2
         )
     else:
         fps = pkl["fps"]


### PR DESCRIPTION
Adding parenthesis to fix calculation.

np.mean of invervalsms will return approx 16.0
- multiplied by 0.001 gives 0.016 (approximately 1/60th sec)
- This, wrapped by parenthesis, then used to divide 1 gives the correct value in frames per second