### PR TITLE
Return instrument as object

### DIFF
--- a/src/aind_metadata_mapper/fip/make_instrument.py
+++ b/src/aind_metadata_mapper/fip/make_instrument.py
@@ -53,7 +53,7 @@ def create_instrument(
     detector_1_serial: Optional[str] = None,
     detector_2_serial: Optional[str] = None,
     objective_serial: Optional[str] = None,
-    previous_instrument: Optional[dict] = None,
+    previous_instrument: Optional[instrument.Instrument] = None,
     input_func=input,
 ) -> instrument.Instrument:
     """Create an FIP instrument interactively.
@@ -72,8 +72,8 @@ def create_instrument(
         Red CMOS serial number. If None, will prompt (required if no previous instrument).
     objective_serial : Optional[str]
         Objective serial number. If None, will prompt (required if no previous instrument).
-    previous_instrument : Optional[dict]
-        Optional previous instrument data as dict. Used for defaults.
+    previous_instrument : Optional[Instrument]
+        Optional previous instrument. Used for defaults.
 
     Returns
     -------
@@ -98,21 +98,17 @@ def create_instrument(
         - modification_date (date.today())
     """
     # Get previous instrument components for defaults
-    previous_instrument_obj = None
-    if previous_instrument:
-        previous_instrument_obj = instrument.Instrument.model_validate(previous_instrument)
-
     components_by_name = {}
-    if previous_instrument_obj:
+    if previous_instrument:
         components_by_name = {
             getattr(component, "name", ""): component
-            for component in previous_instrument_obj.components
+            for component in previous_instrument.components
             if getattr(component, "name", None)
         }
 
     # Get defaults from previous instrument or system
     defaults = {
-        "location": previous_instrument_obj.location if previous_instrument_obj else None,
+        "location": previous_instrument.location if previous_instrument else None,
         "computer_name": socket.gethostname(),
         "detector_1_serial": getattr(components_by_name.get("Green CMOS"), "serial_number", None),
         "detector_2_serial": getattr(components_by_name.get("Red CMOS"), "serial_number", None),

--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -368,12 +368,11 @@ class GatherMetadataJob:
                 base_url=base_url,
             )
             if instrument:
-                # Write this instrument using it's modalities
-                modality_abbreviations = [mod["abbreviation"] for mod in instrument.get("modalities", [])]
+                modality_abbreviations = [mod.abbreviation for mod in instrument.modalities]
                 instrument_suffix = "_".join(modality_abbreviations)
                 self._write_json_file(
                     filename=f"instrument_{instrument_suffix}.json",
-                    contents=instrument,
+                    contents=instrument.model_dump(mode="json"),
                     output_dir=False,
                 )
 

--- a/src/aind_metadata_mapper/utils.py
+++ b/src/aind_metadata_mapper/utils.py
@@ -244,7 +244,7 @@ def get_instrument(
     prefix: Optional[str] = None,
     filename_suffix: Optional[str] = None,
     suffix: Optional[str] = None,
-) -> Optional[dict]:
+) -> Optional[instrument.Instrument]:
     """Get instrument.
 
     Gets the latest record by default, or a specific record if modification_date is provided.
@@ -271,8 +271,8 @@ def get_instrument(
 
     Returns
     -------
-    Optional[dict]
-        Instrument data as dict, or None if not found.
+    Optional[Instrument]
+        Instrument model, or None if not found.
     """
     try:
         url_base = base_url.rstrip("/") + "/"
@@ -318,7 +318,9 @@ def get_instrument(
                 filename_suffix=filename_suffix,
                 suffix=suffix,
             )
-        return record
+        if record is not None:
+            return instrument.Instrument.model_validate(record)
+        return None
     except Exception as e:
         logger.warning(f"Unexpected error fetching instrument {instrument_id}: {e}")
         return None
@@ -392,12 +394,11 @@ def save_instrument(
         f"GETting instrument from {INSTRUMENT_BASE_URL}/{instrument_model.instrument_id} "
         "to verify that save was successful"
     )
-    latest_record = get_instrument(instrument_model.instrument_id)
-    if latest_record is None:
+    read_back_instrument = get_instrument(instrument_model.instrument_id)
+    if read_back_instrument is None:
         raise ValueError(f"Instrument '{instrument_model.instrument_id}' not found in database")
 
     # Validate round-trip
-    read_back_instrument = instrument.Instrument.model_validate(latest_record)
     read_back_dict = json.loads(read_back_instrument.model_dump_json())
     if source_dict == read_back_dict:
         logger.info("Instrument.json successfully stored in the db")
@@ -435,7 +436,7 @@ def check_instrument_id(
     instrument_id: str,
     skip_confirmation: bool = False,
     input_func=input,
-) -> Optional[dict]:
+) -> Optional[instrument.Instrument]:
     """Check if instrument exists and get previous instrument data.
 
     Checks if records exist for the given instrument_id and returns the
@@ -452,8 +453,8 @@ def check_instrument_id(
 
     Returns
     -------
-    Optional[dict]
-        Previous instrument data as dict, or None if not found.
+    Optional[Instrument]
+        Previous instrument, or None if not found.
 
     Raises
     ------

--- a/tests/test_integration_metadata.py
+++ b/tests/test_integration_metadata.py
@@ -585,7 +585,9 @@ class TestIntegrationMetadata(unittest.TestCase):
     def test_get_instrument_from_service(self, mock_get_instrument):
         """Test get_instrument_from_service retrieves and writes instrument metadata"""
         instrument_data = self._load_resource_file(METADATA_SERVICE_DIR, "instrument_response.json")
-        mock_get_instrument.return_value = instrument_data
+        from aind_data_schema.core.instrument import Instrument
+
+        mock_get_instrument.return_value = Instrument.model_validate(instrument_data)
 
         with patch("os.makedirs"):
             test_job = GatherMetadataJob(
@@ -605,7 +607,11 @@ class TestIntegrationMetadata(unittest.TestCase):
             test_job.get_instrument_from_service()
 
         mock_get_instrument.assert_called_once()
-        mock_write.assert_called_once_with(filename="instrument_fib.json", contents=instrument_data, output_dir=False)
+        mock_write.assert_called_once()
+        call_kwargs = mock_write.call_args[1]
+        self.assertEqual(call_kwargs["filename"], "instrument_fib.json")
+        self.assertIn("instrument_id", call_kwargs["contents"])
+        self.assertEqual(call_kwargs["output_dir"], False)
 
     @patch("builtins.open", new_callable=unittest.mock.mock_open)
     @patch("os.makedirs")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
+import aind_data_schema.core.instrument as instrument
 from aind_metadata_mapper.utils import (
     check_existing_instrument,
     check_instrument_id,
@@ -47,32 +48,30 @@ class TestGetInstrument(unittest.TestCase):
         result = get_instrument("nonexistent_id")
         self.assertIsNone(result)
 
-    @patch("aind_metadata_mapper.utils.requests.get")
-    def test_get_instrument_returns_latest(self, mock_get):
-        """Test get_instrument returns latest record."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = [
-            {"instrument_id": "test_id", "modification_date": "2024-01-01"},
-            {"instrument_id": "test_id", "modification_date": "2024-01-03"},
-            {"instrument_id": "test_id", "modification_date": "2024-01-02"},
-        ]
-        mock_get.return_value = mock_response
-        result = get_instrument("test_id")
-        self.assertEqual(result["modification_date"], "2024-01-03")
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_get_instrument_returns_latest(self, mock_helper):
+        """Test get_instrument returns latest record as Instrument."""
+        with open(INSTRUMENT_JSON) as f:
+            data = json.load(f)
+        data["modification_date"] = "2024-01-03"
+        mock_helper.return_value = [data]
+        result = get_instrument("422_MESO2_20241017")
+        self.assertIsNotNone(result)
+        self.assertEqual(str(result.modification_date), "2024-01-03")
 
-    @patch("aind_metadata_mapper.utils.requests.get")
-    def test_get_instrument_by_date(self, mock_get):
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_get_instrument_by_date(self, mock_helper):
         """Test get_instrument returns specific date if provided."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = [
-            {"instrument_id": "test_id", "modification_date": "2024-01-01"},
-            {"instrument_id": "test_id", "modification_date": "2024-01-02"},
+        with open(INSTRUMENT_JSON) as f:
+            data = json.load(f)
+        records = [
+            {**data, "modification_date": "2024-01-01"},
+            {**data, "modification_date": "2024-01-02"},
         ]
-        mock_get.return_value = mock_response
-        result = get_instrument("test_id", modification_date="2024-01-01")
-        self.assertEqual(result["modification_date"], "2024-01-01")
+        mock_helper.return_value = records
+        result = get_instrument("422_MESO2_20241017", modification_date="2024-01-01")
+        self.assertIsNotNone(result)
+        self.assertEqual(str(result.modification_date), "2024-01-01")
 
     @patch("aind_metadata_mapper.utils.metadata_service_helper")
     def test_get_instrument_writes_to_file_when_output_directory_given(self, mock_helper):
@@ -89,7 +88,7 @@ class TestGetInstrument(unittest.TestCase):
     def test_save_instrument_loads_from_filepath(self, mock_post, mock_get):
         """save_instrument loads from file when given a path."""
         with open(INSTRUMENT_JSON) as f:
-            mock_get.return_value = json.load(f)
+            mock_get.return_value = instrument.Instrument.model_validate(json.load(f))
         mock_post.return_value = MagicMock(status_code=201)
         save_instrument(str(INSTRUMENT_JSON))
         mock_post.assert_called_once()
@@ -97,17 +96,20 @@ class TestGetInstrument(unittest.TestCase):
     @patch("aind_metadata_mapper.utils.get_instrument")
     def test_check_existing_instrument(self, mock_get):
         """check_existing_instrument returns True when instrument exists."""
-        mock_get.return_value = {"instrument_id": "test_instrument", "modification_date": "2024-01-01"}
-        self.assertTrue(check_existing_instrument("test_instrument", "2024-01-01"))
+        with open(INSTRUMENT_JSON) as f:
+            mock_get.return_value = instrument.Instrument.model_validate(json.load(f))
+        self.assertTrue(check_existing_instrument("422_MESO2_20241017", "2024-10-28"))
         mock_get.return_value = None
         self.assertFalse(check_existing_instrument("test_instrument", "2024-01-01"))
 
     @patch("aind_metadata_mapper.utils.get_instrument")
     def test_check_instrument_id(self, mock_get):
         """check_instrument_id returns existing instrument or None."""
-        mock_get.return_value = {"instrument_id": "test_instrument"}
-        expected = {"instrument_id": "test_instrument"}
-        self.assertEqual(check_instrument_id("test_instrument", skip_confirmation=True), expected)
+        with open(INSTRUMENT_JSON) as f:
+            mock_get.return_value = instrument.Instrument.model_validate(json.load(f))
+        result = check_instrument_id("422_MESO2_20241017", skip_confirmation=True)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.instrument_id, "422_MESO2_20241017")
         mock_get.return_value = None
         self.assertIsNone(check_instrument_id("test_instrument_new", skip_confirmation=True))
 
@@ -122,6 +124,15 @@ class TestGetInstrument(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             check_instrument_id("test_instrument_new", skip_confirmation=False, input_func=user_declines)
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_get_instrument_returns_instrument_model(self, mock_helper):
+        """get_instrument returns Instrument model."""
+        with open(INSTRUMENT_JSON) as f:
+            mock_helper.return_value = [json.load(f)]
+        result = get_instrument("422_MESO2_20241017")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.instrument_id, "422_MESO2_20241017")
 
     @patch("aind_metadata_mapper.utils.metadata_service_helper")
     def test_get_instrument_returns_none_when_helper_fails(self, mock_helper):
@@ -145,9 +156,10 @@ class TestGetInstrument(unittest.TestCase):
         """save_instrument raises on 400, 500, not found, and round-trip failure."""
         with open(INSTRUMENT_JSON) as f:
             instrument_data = json.load(f)
+        instrument_model = instrument.Instrument.model_validate(instrument_data)
 
         for status_code, get_return, expected_msg in [
-            (400, instrument_data, "exists"),
+            (400, instrument_model, "exists"),
             (201, None, "not found"),
         ]:
             with self.subTest(status_code=status_code, expected=expected_msg):
@@ -159,7 +171,7 @@ class TestGetInstrument(unittest.TestCase):
 
         instrument_data["location"] = "different"
         mock_post.return_value = MagicMock(status_code=201)
-        mock_get.return_value = instrument_data
+        mock_get.return_value = instrument.Instrument.model_validate(instrument_data)
         with self.assertRaises(ValueError) as cm:
             save_instrument(str(INSTRUMENT_JSON))
         self.assertIn("Round-trip", str(cm.exception))


### PR DESCRIPTION
After exercising the `get_instrument` method a bit more I realized it's easier to work with if it returns an Instrument object, not a dict. 

This makes changes to do that, including changes to tests and changes to locations where get_instrument is being used.