### PR TITLE
Add instrument CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,30 @@ You probably shouldn't be modifying these.
   - `metadata_service_procedures_endpoint` (default="/api/v2/procedures/")
   - `metadata_service_instrument_endpoint` (default="/api/v2/instrument/")
 
+### Instrument CLI
+
+The `aind-instrument` command lets you upload and retrieve instruments from the metadata service without writing code.
+
+```bash
+# Upload an instrument
+aind-instrument upload instrument.json
+
+# Upload and overwrite an existing record
+aind-instrument upload instrument.json --replace
+
+# Keep the modification date from the file instead of updating to today
+aind-instrument upload instrument.json --no-update-modification-date
+
+# Get the latest record for an instrument
+aind-instrument get 422_MESO2_20241017
+
+# Get a specific version by modification date
+aind-instrument get 422_MESO2_20241017 --modification-date 2024-10-28
+
+# Save to a file instead of printing to stdout
+aind-instrument get 422_MESO2_20241017 --output-directory ./output
+```
+
 ### Developing Mappers
 
 Each MapperJob class should inherit from `BaseMapper` in `base.py`. The only parameter should be the `MapperJobSettings` from `base.py`. You cannot add additional parameters to your job or it will not be possible for it to be run automatically on the data-transfer-service. GatherMetadataJob will then run your mappers automatically when it detects the extracted metadata output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ doc = [
     "furo"
 ]
 
+[project.scripts]
+aind-instrument = "aind_metadata_mapper.cli.instrument:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/aind_metadata_mapper/cli/__init__.py
+++ b/src/aind_metadata_mapper/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI tools for AIND metadata mapper."""

--- a/src/aind_metadata_mapper/cli/instrument.py
+++ b/src/aind_metadata_mapper/cli/instrument.py
@@ -1,0 +1,106 @@
+"""CLI for instrument database operations.
+
+Provides ``upload`` and ``get`` subcommands for working with the AIND
+instrument metadata service.
+
+Usage::
+
+    aind-instrument upload instrument.json
+    aind-instrument upload instrument.json --replace
+    aind-instrument upload instrument.json --no-update-modification-date  # keep date from file
+    aind-instrument get 422_MESO2_20241017
+    aind-instrument get 422_MESO2_20241017 --modification-date 2024-10-28
+    aind-instrument get 422_MESO2_20241017 --output-directory ./output
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+from pydantic_settings import CliApp, CliPositionalArg, CliSubCommand
+
+from aind_metadata_mapper.utils import get_instrument, save_instrument
+
+logger = logging.getLogger(__name__)
+
+
+class Upload(BaseModel):
+    """Upload an instrument JSON file to the metadata service database."""
+
+    file: CliPositionalArg[Path] = Field(
+        description="Path to an instrument JSON file to upload.",
+    )
+    replace: bool = Field(
+        default=False,
+        description=("If set, overwrite an existing record with the same " "instrument_id and modification_date."),
+    )
+    update_modification_date: bool = Field(
+        default=True,
+        description=(
+            "Update modification_date to today's date."
+            " Use --no-update-modification-date to keep the date from the file."
+        ),
+    )
+
+    def cli_cmd(self) -> None:
+        """Upload an instrument JSON to the database."""
+        try:
+            save_instrument(
+                self.file,
+                replace=self.replace,
+                update_modification_date=self.update_modification_date,
+            )
+        except Exception as e:
+            logger.error(f"Upload failed: {e}")
+            sys.exit(1)
+
+
+class Get(BaseModel):
+    """Retrieve an instrument record from the metadata service database."""
+
+    instrument_id: CliPositionalArg[str] = Field(
+        description="Instrument identifier to look up.",
+    )
+    modification_date: Optional[str] = Field(
+        default=None,
+        description=("Specific modification date (YYYY-MM-DD) to retrieve. " "If omitted, returns the latest record."),
+    )
+    output_directory: Optional[Path] = Field(
+        default=None,
+        description=("Directory to save the instrument JSON file. " "If omitted, prints the JSON to stdout."),
+    )
+
+    def cli_cmd(self) -> None:
+        """Get an instrument record and display or save it."""
+        result = get_instrument(
+            self.instrument_id,
+            modification_date=self.modification_date,
+            output_directory=self.output_directory,
+        )
+        if result is None:
+            logger.error(f"Instrument '{self.instrument_id}' not found.")
+            sys.exit(1)
+        if self.output_directory is None:
+            print(result.model_dump_json(indent=3))
+
+
+class InstrumentCLI(BaseModel):
+    """CLI for instrument database operations."""
+
+    upload: CliSubCommand[Upload]
+    get: CliSubCommand[Get]
+
+    def cli_cmd(self) -> None:
+        """Dispatch to the active subcommand."""
+        CliApp.run_subcommand(self)
+
+
+def main() -> None:
+    """Entry point for the aind-instrument CLI."""
+    CliApp.run(InstrumentCLI)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aind_metadata_mapper/cli/instrument.py
+++ b/src/aind_metadata_mapper/cli/instrument.py
@@ -21,9 +21,14 @@ from typing import Optional
 from pydantic import BaseModel, Field
 from pydantic_settings import CliApp, CliPositionalArg, CliSubCommand
 
-from aind_metadata_mapper.utils import get_instrument, save_instrument
+from aind_metadata_mapper.utils import INSTRUMENT_BASE_URL, get_instrument, save_instrument
 
 logger = logging.getLogger(__name__)
+
+BASE_URL_FIELD = Field(
+    default=INSTRUMENT_BASE_URL,
+    description="Base URL for the instrument metadata service.",
+)
 
 
 class Upload(BaseModel):
@@ -43,6 +48,7 @@ class Upload(BaseModel):
             " Use --no-update-modification-date to keep the date from the file."
         ),
     )
+    base_url: str = BASE_URL_FIELD
 
     def cli_cmd(self) -> None:
         """Upload an instrument JSON to the database."""
@@ -51,6 +57,7 @@ class Upload(BaseModel):
                 self.file,
                 replace=self.replace,
                 update_modification_date=self.update_modification_date,
+                base_url=self.base_url,
             )
         except Exception as e:
             logger.error(f"Upload failed: {e}")
@@ -71,6 +78,7 @@ class Get(BaseModel):
         default=None,
         description=("Directory to save the instrument JSON file. " "If omitted, prints the JSON to stdout."),
     )
+    base_url: str = BASE_URL_FIELD
 
     def cli_cmd(self) -> None:
         """Get an instrument record and display or save it."""
@@ -78,6 +86,7 @@ class Get(BaseModel):
             self.instrument_id,
             modification_date=self.modification_date,
             output_directory=self.output_directory,
+            base_url=self.base_url,
         )
         if result is None:
             logger.error(f"Instrument '{self.instrument_id}' not found.")

--- a/src/aind_metadata_mapper/utils.py
+++ b/src/aind_metadata_mapper/utils.py
@@ -349,6 +349,7 @@ def save_instrument(
     instrument_model: instrument.Instrument | dict | str | Path,
     replace: bool = False,
     update_modification_date: bool = True,
+    base_url: str = INSTRUMENT_BASE_URL,
 ) -> None:
     """Save instrument and validate round-trip.
 
@@ -365,6 +366,8 @@ def save_instrument(
     update_modification_date : bool
         If True (default), set modification_date to today (YYYY-MM-DD). If False,
         keep the modification date as passed in the instrument.
+    base_url : str
+        Base URL for the instrument endpoint. Defaults to INSTRUMENT_BASE_URL.
 
     Raises
     ------
@@ -386,9 +389,9 @@ def save_instrument(
 
     # Use model_dump_json() and parse to ensure dates are properly serialized
     source_dict = json.loads(instrument_model.model_dump_json())
-    logger.info(f"POSTing instrument to {INSTRUMENT_BASE_URL}")
+    logger.info(f"POSTing instrument to {base_url}")
     params = {"replace": "true"} if replace else {}
-    response = requests.post(INSTRUMENT_BASE_URL, json=source_dict, params=params)
+    response = requests.post(base_url, json=source_dict, params=params)
     # POST 400 is always an error (e.g., "Record already exists")
     if response.status_code == 400:
         error_msg = response.json().get("message", response.text)
@@ -398,10 +401,9 @@ def save_instrument(
 
     # GET back and validate round-trip
     logger.info(
-        f"GETting instrument from {INSTRUMENT_BASE_URL}/{instrument_model.instrument_id} "
-        "to verify that save was successful"
+        f"GETting instrument from {base_url}/{instrument_model.instrument_id} " "to verify that save was successful"
     )
-    read_back_instrument = get_instrument(instrument_model.instrument_id)
+    read_back_instrument = get_instrument(instrument_model.instrument_id, base_url=base_url)
     if read_back_instrument is None:
         raise ValueError(f"Instrument '{instrument_model.instrument_id}' not found in database")
 

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for CLI module."""

--- a/tests/cli/test_instrument.py
+++ b/tests/cli/test_instrument.py
@@ -1,0 +1,171 @@
+"""Tests for instrument CLI commands."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import aind_data_schema.core.instrument as instrument
+
+from aind_metadata_mapper.cli.instrument import Get, Upload
+
+INSTRUMENT_JSON = Path(__file__).parent.parent / "resources" / "v2_metadata" / "instrument.json"
+
+
+class TestUploadCmd(unittest.TestCase):
+    """Tests for the Upload subcommand."""
+
+    @patch("aind_metadata_mapper.cli.instrument.save_instrument")
+    def test_upload_default_flags(self, mock_save):
+        """Upload passes file path and default flags to save_instrument."""
+        cmd = Upload(file=INSTRUMENT_JSON)
+        cmd.cli_cmd()
+        mock_save.assert_called_once_with(
+            INSTRUMENT_JSON,
+            replace=False,
+            update_modification_date=True,
+        )
+
+    @patch("aind_metadata_mapper.cli.instrument.save_instrument")
+    def test_upload_with_replace(self, mock_save):
+        """Upload passes replace=True when flag is set."""
+        cmd = Upload(file=INSTRUMENT_JSON, replace=True)
+        cmd.cli_cmd()
+        mock_save.assert_called_once_with(
+            INSTRUMENT_JSON,
+            replace=True,
+            update_modification_date=True,
+        )
+
+    @patch("aind_metadata_mapper.cli.instrument.save_instrument")
+    def test_upload_no_update_modification_date(self, mock_save):
+        """Upload passes update_modification_date=False when flag is set."""
+        cmd = Upload(file=INSTRUMENT_JSON, update_modification_date=False)
+        cmd.cli_cmd()
+        mock_save.assert_called_once_with(
+            INSTRUMENT_JSON,
+            replace=False,
+            update_modification_date=False,
+        )
+
+    @patch("aind_metadata_mapper.cli.instrument.save_instrument")
+    def test_upload_exits_on_error(self, mock_save):
+        """Upload exits with code 1 when save_instrument raises."""
+        mock_save.side_effect = ValueError("Record already exists")
+        cmd = Upload(file=INSTRUMENT_JSON)
+        with self.assertRaises(SystemExit) as cm:
+            cmd.cli_cmd()
+        self.assertEqual(cm.exception.code, 1)
+
+
+class TestGetCmd(unittest.TestCase):
+    """Tests for the Get subcommand."""
+
+    @patch("aind_metadata_mapper.cli.instrument.get_instrument")
+    def test_get_prints_json_to_stdout(self, mock_get):
+        """Get prints instrument JSON to stdout when no output_directory."""
+        with open(INSTRUMENT_JSON) as f:
+            data = json.load(f)
+        mock_get.return_value = instrument.Instrument.model_validate(data)
+        cmd = Get(instrument_id="422_MESO2_20241017")
+        with patch("builtins.print") as mock_print:
+            cmd.cli_cmd()
+        mock_get.assert_called_once_with(
+            "422_MESO2_20241017",
+            modification_date=None,
+            output_directory=None,
+        )
+        mock_print.assert_called_once()
+        # Verify it's valid JSON
+        json.loads(mock_print.call_args[0][0])
+
+    @patch("aind_metadata_mapper.cli.instrument.get_instrument")
+    def test_get_with_modification_date(self, mock_get):
+        """Get passes modification_date to get_instrument."""
+        with open(INSTRUMENT_JSON) as f:
+            data = json.load(f)
+        mock_get.return_value = instrument.Instrument.model_validate(data)
+        cmd = Get(instrument_id="422_MESO2_20241017", modification_date="2024-10-28")
+        with patch("builtins.print"):
+            cmd.cli_cmd()
+        mock_get.assert_called_once_with(
+            "422_MESO2_20241017",
+            modification_date="2024-10-28",
+            output_directory=None,
+        )
+
+    @patch("aind_metadata_mapper.cli.instrument.get_instrument")
+    def test_get_with_output_directory(self, mock_get):
+        """Get passes output_directory and does not print to stdout."""
+        with open(INSTRUMENT_JSON) as f:
+            data = json.load(f)
+        mock_get.return_value = instrument.Instrument.model_validate(data)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = Get(instrument_id="422_MESO2_20241017", output_directory=Path(tmpdir))
+            with patch("builtins.print") as mock_print:
+                cmd.cli_cmd()
+            mock_get.assert_called_once_with(
+                "422_MESO2_20241017",
+                modification_date=None,
+                output_directory=Path(tmpdir),
+            )
+            mock_print.assert_not_called()
+
+    @patch("aind_metadata_mapper.cli.instrument.get_instrument")
+    def test_get_exits_when_not_found(self, mock_get):
+        """Get exits with code 1 when instrument is not found."""
+        mock_get.return_value = None
+        cmd = Get(instrument_id="nonexistent")
+        with self.assertRaises(SystemExit) as cm:
+            cmd.cli_cmd()
+        self.assertEqual(cm.exception.code, 1)
+
+
+class TestInstrumentCLIDispatch(unittest.TestCase):
+    """Tests for CLI argument parsing and subcommand dispatch."""
+
+    @patch("aind_metadata_mapper.cli.instrument.save_instrument")
+    def test_cli_dispatches_upload(self, mock_save):
+        """CliApp.run dispatches upload subcommand from sys.argv."""
+        from pydantic_settings import CliApp
+
+        from aind_metadata_mapper.cli.instrument import InstrumentCLI
+
+        cli = CliApp.run(
+            InstrumentCLI,
+            cli_args=["upload", str(INSTRUMENT_JSON)],
+        )
+        mock_save.assert_called_once()
+        self.assertIsNotNone(cli.upload)
+
+    @patch("aind_metadata_mapper.cli.instrument.CliApp")
+    def test_main_calls_cli_app_run(self, mock_cli_app):
+        """main() calls CliApp.run with InstrumentCLI."""
+        from aind_metadata_mapper.cli.instrument import InstrumentCLI, main
+
+        main()
+        mock_cli_app.run.assert_called_once_with(InstrumentCLI)
+
+    @patch("aind_metadata_mapper.cli.instrument.get_instrument")
+    def test_cli_dispatches_get(self, mock_get):
+        """CliApp.run dispatches get subcommand from sys.argv."""
+        with open(INSTRUMENT_JSON) as f:
+            data = json.load(f)
+        mock_get.return_value = instrument.Instrument.model_validate(data)
+
+        from pydantic_settings import CliApp
+
+        from aind_metadata_mapper.cli.instrument import InstrumentCLI
+
+        with patch("builtins.print"):
+            cli = CliApp.run(
+                InstrumentCLI,
+                cli_args=["get", "422_MESO2_20241017"],
+            )
+        mock_get.assert_called_once()
+        self.assertIsNotNone(cli.get)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cli/test_instrument.py
+++ b/tests/cli/test_instrument.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import aind_data_schema.core.instrument as instrument
 
 from aind_metadata_mapper.cli.instrument import Get, Upload
+from aind_metadata_mapper.utils import INSTRUMENT_BASE_URL
 
 INSTRUMENT_JSON = Path(__file__).parent.parent / "resources" / "v2_metadata" / "instrument.json"
 
@@ -25,6 +26,7 @@ class TestUploadCmd(unittest.TestCase):
             INSTRUMENT_JSON,
             replace=False,
             update_modification_date=True,
+            base_url=INSTRUMENT_BASE_URL,
         )
 
     @patch("aind_metadata_mapper.cli.instrument.save_instrument")
@@ -36,6 +38,7 @@ class TestUploadCmd(unittest.TestCase):
             INSTRUMENT_JSON,
             replace=True,
             update_modification_date=True,
+            base_url=INSTRUMENT_BASE_URL,
         )
 
     @patch("aind_metadata_mapper.cli.instrument.save_instrument")
@@ -47,6 +50,7 @@ class TestUploadCmd(unittest.TestCase):
             INSTRUMENT_JSON,
             replace=False,
             update_modification_date=False,
+            base_url=INSTRUMENT_BASE_URL,
         )
 
     @patch("aind_metadata_mapper.cli.instrument.save_instrument")
@@ -75,6 +79,7 @@ class TestGetCmd(unittest.TestCase):
             "422_MESO2_20241017",
             modification_date=None,
             output_directory=None,
+            base_url=INSTRUMENT_BASE_URL,
         )
         mock_print.assert_called_once()
         # Verify it's valid JSON
@@ -93,6 +98,7 @@ class TestGetCmd(unittest.TestCase):
             "422_MESO2_20241017",
             modification_date="2024-10-28",
             output_directory=None,
+            base_url=INSTRUMENT_BASE_URL,
         )
 
     @patch("aind_metadata_mapper.cli.instrument.get_instrument")
@@ -109,6 +115,7 @@ class TestGetCmd(unittest.TestCase):
                 "422_MESO2_20241017",
                 modification_date=None,
                 output_directory=Path(tmpdir),
+                base_url=INSTRUMENT_BASE_URL,
             )
             mock_print.assert_not_called()
 


### PR DESCRIPTION
The [documentation for uploading data](https://docs.allenneuraldynamics.org/en/latest/acquire_upload/prepare_before_acquisition.html#i-m-ready-to-upload-my-instrument-json-file-to-the-database) instructs users to write and run a python script when they want to get and upload instruments. It would be nice if this package handled that for users, instead of telling people to copy and paste a script.

This commit introduces a CLI interface for uploading and getting instruments without writing code. The main command, `aind-instrument`, has two subcommands that are thin wrappers around existing functions.
- `aind-instrument upload`: thin wrapper around `save_instrument`
- `aind-instrument get`: thin wrapper around `get_instrument`

The usage is:

```bash
aind-instrument upload instrument.json
aind-instrument upload instrument.json --replace
aind-instrument upload instrument.json --no-update-modification-date  # keep date from file
aind-instrument get 422_MESO2_20241017
aind-instrument get 422_MESO2_20241017 --modification-date 2024-10-28
aind-instrument get 422_MESO2_20241017 --output-directory ./output
```

These CLI tools make the scripts in the documentation unnecessary.