### PR TITLE
Update extractor version pin and bump version to 1.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pydantic-settings>=2.8.0",
     "jsonschema",
     "aind-data-schema>=2.6.0,<3",
-    "aind-metadata-extractor==0.3.9",
+    "aind-metadata-extractor==0.3.11",
 ]
 
 [project.optional-dependencies]

--- a/src/aind_metadata_mapper/__init__.py
+++ b/src/aind_metadata_mapper/__init__.py
@@ -1,3 +1,3 @@
 """Init package"""
 
-__version__ = "1.1.0"
+__version__ = "1.2.1"


### PR DESCRIPTION
Closes #459 
* Updates extractor repo pin to make data_directory optional
* Updates mapper version to 1.2.1