### PR TITLE
feat: auto-populate the subject and procedures 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ If no exact match exists, it will construct, fetch, merge or run mappers to gene
 | File | Method 1 | Method 2 | Method 3 |
 |------|----------|----------|----------|
 | data_description.json | Exact match in input directory | Construct from settings / fetch from metadata-service |  |
-| subject.json | Exact match in input directory | Fetch from metadata-service (requires subject_id) |  |
-| procedures.json | Exact match in input directory | Fetch from metadata-service (requires subject_id) |  |
+| subject.json | Exact match in input directory | Fetch from metadata-service (requires subject_id) | Constructed locally when subject_id is "calibration" |
+| procedures.json | Exact match in input directory | Fetch from metadata-service (requires subject_id) | Constructed locally (empty) when subject_id is "calibration" |
 | acquisition.json | Exact match in input directory | Run mappers on `<mapper>.json` files (and merge) | Merge all `acquisition*.json` files |
 | instrument.json | Exact match in input directory | Fetch from metadata-service (requires instrument_id) | Merge all `instrument*.json` files |
 | processing.json | Exact match in input directory |  |  |
@@ -70,6 +70,9 @@ When mappers are developed from the `BaseMapper` class and registered in `mapper
 - **`subject_id`** (str): Subject ID used to fetch metadata from the service (subject.json, procedures.json). This setting should only be used when an `acquisition.json` is not available.
 
 - **`acquisition_start_time`** (datetime, optional): Acquisition start time in ISO 8601 format. This setting should only be used when an `acquisition.json` is not available.
+
+- **`subject_settings`** (optional): Settings for subject metadata. Only used when `subject_id` is `"calibration"`.
+  - **`calibration_object`** ([CalibrationObject](https://aind-data-schema.readthedocs.io/en/latest/), optional): A `CalibrationObject` from `aind_data_schema.components.subjects`. When `subject_id` is `"calibration"`, the metadata service is not contacted — instead a `Subject` is constructed locally using this object and an empty `Procedures` (no subject or specimen procedures). If omitted, a default empty `CalibrationObject` is used.
 
 - **`instrument_settings`**:
   - **`instrument_id`** (str): ID for the instrument used in data collection. When set, the instrument.json will attempt to be fetched from the metadata-service and saved as `instrument_<modality-abbreviation(s)>.json`. If multiple `instrument*.json` files exist after fetching they will be merged.
@@ -107,6 +110,35 @@ job_settings = JobSettings(
     raise_if_invalid=True,
     raise_if_mapper_errors=True,
     metadata_service_url="http://aind-metadata-service",
+)
+
+job = GatherMetadataJob(job_settings=job_settings)
+job.run_job()
+```
+
+#### Calibration sessions
+
+When collecting data with a calibration object rather than a live subject, set `subject_id` to `"calibration"`. The job will skip the metadata service entirely and construct `subject.json` and `procedures.json` locally.
+
+```python
+from aind_data_schema.components.subjects import CalibrationObject
+from aind_data_schema_models.modalities import Modality
+from aind_metadata_mapper.gather_metadata import GatherMetadataJob
+from aind_metadata_mapper.models import JobSettings, DataDescriptionSettings, SubjectSettings
+
+job_settings = JobSettings(
+    output_dir="/path/to/output",
+    subject_id="calibration",
+    data_description_settings=DataDescriptionSettings(
+        project_name="<project-name>",
+        modalities=[Modality.ECEPHYS],
+    ),
+    subject_settings=SubjectSettings(
+        calibration_object=CalibrationObject(
+            description="Neuropixels dummy probe",
+            empty=False,
+        )
+    ),
 )
 
 job = GatherMetadataJob(job_settings=job_settings)

--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 
+from aind_data_schema.components.subjects import CalibrationObject
 from aind_data_schema.core.acquisition import Acquisition
 from aind_data_schema.core.data_description import DataDescription
 from aind_data_schema.core.instrument import Instrument
@@ -246,6 +247,16 @@ class GatherMetadataJob:
             logging.warning("No subject_id provided.")
             return None
 
+        if subject_id == "calibration":
+            logging.info("subject_id is 'calibration'; constructing Subject locally.")
+            calibration_object = (
+                self.settings.subject_settings.calibration_object
+                if self.settings.subject_settings and self.settings.subject_settings.calibration_object
+                else CalibrationObject(description="", empty=True)
+            )
+            subject = Subject(subject_id=subject_id, subject_details=calibration_object)
+            return json.loads(subject.model_dump_json())
+
         if not self._does_file_exist_in_user_defined_dir(file_name=file_name):
             logging.debug(
                 f"No subject file found in directory. Downloading "
@@ -276,6 +287,11 @@ class GatherMetadataJob:
         if not subject_id:
             logging.warning("No subject_id provided.")
             return None
+
+        if subject_id == "calibration":
+            logging.info("subject_id is 'calibration'; constructing empty Procedures locally.")
+            procedures = Procedures(subject_id=subject_id)
+            return json.loads(procedures.model_dump_json())
 
         if not self._does_file_exist_in_user_defined_dir(file_name=file_name):
             logging.debug(

--- a/src/aind_metadata_mapper/models.py
+++ b/src/aind_metadata_mapper/models.py
@@ -3,6 +3,7 @@
 from typing import List, Optional
 
 from aind_data_schema.base import AwareDatetimeWithDefault
+from aind_data_schema.components.subjects import CalibrationObject
 from aind_data_schema_models.data_name_patterns import Group
 from aind_data_schema_models.modalities import Modality
 from pydantic import Field, field_validator
@@ -45,6 +46,18 @@ class DataDescriptionSettings(BaseSettings):
         elif isinstance(v, list):
             return [Modality.from_abbreviation(mod) if isinstance(mod, str) else mod for mod in v]
         return v
+
+
+class SubjectSettings(BaseSettings):
+    """Settings specific to subject metadata"""
+
+    calibration_object: Optional[CalibrationObject] = Field(
+        default=None,
+        description=(
+            "Optional calibration object. Used when subject_id is 'calibration' to construct "
+            "a Subject without contacting the metadata service."
+        ),
+    )
 
 
 class InstrumentSettings(BaseSettings):
@@ -110,6 +123,10 @@ class JobSettings(BaseSettings, cli_parse_args=True, cli_ignore_unknown_args=Tru
     data_description_settings: DataDescriptionSettings = Field(
         ...,
         description="Settings specific to data description metadata.",
+    )
+    subject_settings: Optional[SubjectSettings] = Field(
+        default=None,
+        description="Settings specific to subject metadata.",
     )
     instrument_settings: Optional[InstrumentSettings] = Field(
         default=None,

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -12,12 +12,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
+from aind_data_schema.components.subjects import CalibrationObject
 from aind_data_schema.core.acquisition import Acquisition
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 
 from aind_metadata_mapper.gather_metadata import GatherMetadataJob
-from aind_metadata_mapper.models import DataDescriptionSettings, JobSettings
+from aind_metadata_mapper.models import DataDescriptionSettings, JobSettings, SubjectSettings
 
 TEST_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 
@@ -607,6 +608,52 @@ class TestGatherMetadataJob(unittest.TestCase):
 
         self.assertIsNone(result)
 
+    @patch("os.makedirs")
+    def test_get_subject_calibration_with_object(self, mock_makedirs):
+        """Test get_subject when subject_id is 'calibration' with CalibrationObject"""
+        calibration_obj = CalibrationObject(description="Test calibration", empty=False)
+        job_settings = JobSettings(
+            metadata_dir="/test",
+            output_dir="/test/output",
+            subject_id="calibration",
+            data_description_settings=DataDescriptionSettings(
+                project_name="Test Project",
+                modalities=[Modality.ECEPHYS],
+            ),
+            subject_settings=SubjectSettings(calibration_object=calibration_obj),
+            acquisition_start_time=datetime(2023, 1, 1, 12, 0, 0),
+        )
+        job = GatherMetadataJob(settings=job_settings)
+
+        result = job.get_subject(subject_id="calibration")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["subject_id"], "calibration")
+        self.assertEqual(result["subject_details"]["description"], "Test calibration")
+        self.assertEqual(result["subject_details"]["empty"], False)
+
+    @patch("os.makedirs")
+    def test_get_subject_calibration_without_object(self, mock_makedirs):
+        """Test get_subject when subject_id is 'calibration' without CalibrationObject"""
+        job_settings = JobSettings(
+            metadata_dir="/test",
+            output_dir="/test/output",
+            subject_id="calibration",
+            data_description_settings=DataDescriptionSettings(
+                project_name="Test Project",
+                modalities=[Modality.ECEPHYS],
+            ),
+            acquisition_start_time=datetime(2023, 1, 1, 12, 0, 0),
+        )
+        job = GatherMetadataJob(settings=job_settings)
+
+        result = job.get_subject(subject_id="calibration")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["subject_id"], "calibration")
+        self.assertEqual(result["subject_details"]["empty"], True)
+        self.assertEqual(result["subject_details"]["description"], "")
+
     # Tests for get_procedures method
     @patch.object(GatherMetadataJob, "_does_file_exist_in_user_defined_dir")
     @patch("os.makedirs")
@@ -687,6 +734,28 @@ class TestGatherMetadataJob(unittest.TestCase):
         result = self.job.get_procedures(subject_id="123456")
 
         self.assertIsNone(result)
+
+    @patch("os.makedirs")
+    def test_get_procedures_calibration(self, mock_makedirs):
+        """Test get_procedures when subject_id is 'calibration'"""
+        job_settings = JobSettings(
+            metadata_dir="/test",
+            output_dir="/test/output",
+            subject_id="calibration",
+            data_description_settings=DataDescriptionSettings(
+                project_name="Test Project",
+                modalities=[Modality.ECEPHYS],
+            ),
+            acquisition_start_time=datetime(2023, 1, 1, 12, 0, 0),
+        )
+        job = GatherMetadataJob(settings=job_settings)
+
+        result = job.get_procedures(subject_id="calibration")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["subject_id"], "calibration")
+        self.assertEqual(result["subject_procedures"], [])
+        self.assertEqual(result["specimen_procedures"], [])
 
     # Tests for other metadata getter methods
     @patch.object(GatherMetadataJob, "_does_file_exist_in_user_defined_dir")


### PR DESCRIPTION
PR adds support for generating a subject.json and procedures.json automatically for calibrations. This vastly simplifies use of this path for users, and will be documented separately here: https://github.com/AllenNeuralDynamics/aind-software-docs/issues/117