### PR TITLE
feat: merge user-provided procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Repository to contain code that will parse source files into aind-data-schema mo
 
 ## Usage
 
-The `GatherMetadataJob` is used to create the `data_description.json` and pull the `subject.json` and `procedures.json` from `aind-metadata-service`. Users are expected to provide the `instrument.json` and the `acquisition.json` as well as optional `processing.json`, `quality_control.json` and `model.json`. The job will attempt to validate all of the metadata files, displaying errors, and then will save all metadata fields into the selected folder.
+The `GatherMetadataJob` is used to create the `data_description.json` and pull the `subject.json` and `procedures.json` from `aind-metadata-service`. Users are expected to provide the `instrument.json` and the `acquisition.json` as well as optional `processing.json`, `quality_control.json` and `model.json`. If a user provides `procedures.json`, it will be merged with the procedures fetched from the service (subject and specimen procedures are deduplicated). The job will attempt to validate all of the metadata files, displaying errors, and then will save all metadata fields into the selected folder.
 
 ### Using the GatherMetadataJob
 
@@ -52,7 +52,7 @@ If no exact match exists, it will construct, fetch, merge or run mappers to gene
 |------|----------|----------|----------|
 | data_description.json | Exact match in input directory | Construct from settings / fetch from metadata-service |  |
 | subject.json | Exact match in input directory | Fetch from metadata-service (requires subject_id) |  |
-| procedures.json | Exact match in input directory | Fetch from metadata-service (requires subject_id) |  |
+| procedures.json | Fetch from metadata-service (required) | Merge with user procedures if duplicates are absent | Default to user procedures if duplicates detected |
 | acquisition.json | Exact match in input directory | Run mappers on `<mapper>.json` files (and merge) | Merge all `acquisition*.json` files |
 | instrument.json | Exact match in input directory | Fetch from metadata-service (requires instrument_id) | Merge all `instrument*.json` files |
 | processing.json | Exact match in input directory |  |  |

--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -277,21 +277,29 @@ class GatherMetadataJob:
             logging.warning("No subject_id provided.")
             return None
 
-        if not self._does_file_exist_in_user_defined_dir(file_name=file_name):
-            logging.debug(
-                f"No procedures file found in directory. Downloading "
-                f"{self.settings.subject_id} from "
-                f"{self.settings.metadata_service_url}"
-            )
-            base_url = urljoin(
-                self.settings.metadata_service_url,
-                self.settings.metadata_service_procedures_endpoint,
-            )
-            contents = get_procedures(subject_id, base_url=base_url)
+        base_url = urljoin(
+            self.settings.metadata_service_url,
+            self.settings.metadata_service_procedures_endpoint,
+        )
+        service_procedures = get_procedures(subject_id, base_url=base_url)
+
+        user_procedures = None
+        if self._does_file_exist_in_user_defined_dir(file_name=file_name):
+            logging.debug(f"Found user-provided {file_name}.")
+            user_procedures = self._get_file_from_user_defined_directory(file_name=file_name)
+
+        if user_procedures and service_procedures:
+            logging.info("Merging user-provided and service procedures.")
+            return self._merge_procedures(user_procedures, service_procedures)
+        elif user_procedures:
+            logging.debug(f"Using user-provided {file_name}.")
+            return user_procedures
+        elif service_procedures:
+            logging.debug(f"Using procedures from metadata service.")
+            return service_procedures
         else:
-            logging.debug(f"Using existing {file_name}.")
-            contents = self._get_file_from_user_defined_directory(file_name=file_name)
-        return contents
+            logging.debug("No procedures metadata found.")
+            return None
 
     def _run_mappers_for_acquisition(self):
         """
@@ -356,6 +364,83 @@ class GatherMetadataJob:
             merged_model = merged_model + model
 
         return merged_model.model_dump(mode="json")
+
+    def _merge_procedures(self, user_procedures: dict, service_procedures: dict) -> dict:
+        """Merge user and service procedures, checking for duplicates.
+
+        If duplicates are found, either raises an error or defaults to user procedures
+        based on raise_if_invalid setting.
+
+        Parameters
+        ----------
+        user_procedures : dict
+            User-provided procedures
+        service_procedures : dict
+            Service-fetched procedures
+
+        Returns
+        -------
+        dict
+            Merged procedures using the __add__ operator
+        """
+        logging.info("Merging user and service procedures.")
+        user_proc_obj = Procedures.model_validate(user_procedures)
+        service_proc_obj = Procedures.model_validate(service_procedures)
+
+        # Check for duplicate subject procedures
+        duplicate_subject_procs = self._find_duplicate_procedures(
+            user_proc_obj.subject_procedures or [],
+            service_proc_obj.subject_procedures or [],
+        )
+
+        # Check for duplicate specimen procedures
+        duplicate_specimen_procs = self._find_duplicate_procedures(
+            user_proc_obj.specimen_procedures or [],
+            service_proc_obj.specimen_procedures or [],
+        )
+
+        if duplicate_subject_procs or duplicate_specimen_procs:
+            error_msg = "Found duplicate procedures between user-provided and service procedures"
+            if duplicate_subject_procs:
+                error_msg += f"\n  Duplicate subject procedures: {len(duplicate_subject_procs)}"
+            if duplicate_specimen_procs:
+                error_msg += f"\n  Duplicate specimen procedures: {len(duplicate_specimen_procs)}"
+
+            if self.settings.raise_if_invalid:
+                raise ValueError(error_msg)
+            else:
+                logging.warning(error_msg)
+                logging.info("Defaulting to user-provided procedures")
+                return user_procedures
+
+        # No duplicates, merge using the __add__ operator
+        merged_procedures = user_proc_obj + service_proc_obj
+        return merged_procedures.model_dump(mode="json")
+
+    def _find_duplicate_procedures(self, procedures_1: list, procedures_2: list) -> list:
+        """Find procedures that appear in both lists by comparing objects.
+
+        Parameters
+        ----------
+        procedures_1 : list
+            First list of procedures
+        procedures_2 : list
+            Second list of procedures
+
+        Returns
+        -------
+        list
+            List of procedures that appear in both lists
+        """
+        duplicates = []
+        for proc_1 in procedures_1:
+            proc_1_dict = proc_1.model_dump(mode="json")
+            for proc_2 in procedures_2:
+                proc_2_dict = proc_2.model_dump(mode="json")
+                if proc_1_dict == proc_2_dict:
+                    duplicates.append(proc_1)
+                    break
+        return duplicates
 
     def get_instrument_from_service(self) -> Optional[dict]:
         """Get instrument metadata from service and write to the metadata directory"""

--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -417,10 +417,8 @@ class GatherMetadataJob:
 
         if duplicate_subject_procs or duplicate_specimen_procs:
             error_msg = "Found duplicate procedures between user-provided and service procedures"
-            if duplicate_subject_procs:
-                error_msg += f"\n  Duplicate subject procedures: {len(duplicate_subject_procs)}"
-            if duplicate_specimen_procs:
-                error_msg += f"\n  Duplicate specimen procedures: {len(duplicate_specimen_procs)}"
+            if duplicate_subject_procs or duplicate_specimen_procs:
+                error_msg += f"\n  Duplicate procedures: {len(duplicate_subject_procs) + len(duplicate_specimen_procs)}"
 
             if self.settings.raise_if_invalid:
                 raise ValueError(error_msg)

--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -311,7 +311,7 @@ class GatherMetadataJob:
             logging.debug(f"Using user-provided {file_name}.")
             return user_procedures
         elif service_procedures:
-            logging.debug(f"Using procedures from metadata service.")
+            logging.debug("Using procedures from metadata service.")
             return service_procedures
         else:
             logging.debug("No procedures metadata found.")

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -7,12 +7,17 @@ Do not test run_job() inside this file, use the integration tests.
 
 import json
 import os
+import shutil
+import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 from aind_data_schema.core.acquisition import Acquisition
+from aind_data_schema.core.instrument import Instrument
+from aind_data_schema.core.procedures import Procedures
+from aind_data_schema.core.quality_control import QualityControl
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 
@@ -1223,37 +1228,37 @@ class TestGatherMetadataJob(unittest.TestCase):
 
     def test_find_duplicate_procedures_no_duplicates(self):
         """Test _find_duplicate_procedures when no duplicates exist"""
-        import json
-
         with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
             base_procedures = json.load(f)
 
-        # Create two different procedure lists
-        proc1 = base_procedures.get("subject_procedures", [])[0] if base_procedures.get("subject_procedures") else None
-        proc2 = base_procedures.get("subject_procedures", [])[1] if len(base_procedures.get("subject_procedures", [])) > 1 else None
+        # Validate to get Procedures object with parsed procedures
+        procedures_obj = Procedures.model_validate(base_procedures)
 
-        if proc1 and proc2:
-            from aind_data_schema.core.procedures import Procedures as ProceduresModel
+        if procedures_obj.subject_procedures and len(procedures_obj.subject_procedures) > 1:
+            # Use first two procedures as separate lists (no duplicates between them)
+            procedures_list_1 = [procedures_obj.subject_procedures[0]]
+            procedures_list_2 = [procedures_obj.subject_procedures[1]]
+        else:
+            # If only one procedure, use empty list for no duplicates
+            procedures_list_1 = procedures_obj.subject_procedures or []
+            procedures_list_2 = []
 
-            procedures_list_1 = [ProceduresModel.model_validate_json(json.dumps(proc1))]
-            procedures_list_2 = [ProceduresModel.model_validate_json(json.dumps(proc2))]
-
-            duplicates = self.job._find_duplicate_procedures(procedures_list_1, procedures_list_2)
-            self.assertEqual(len(duplicates), 0)
+        duplicates = self.job._find_duplicate_procedures(procedures_list_1, procedures_list_2)
+        self.assertEqual(len(duplicates), 0)
 
     def test_find_duplicate_procedures_with_duplicates(self):
         """Test _find_duplicate_procedures when duplicates exist"""
-        import json
-
         with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
             base_procedures = json.load(f)
 
-        if base_procedures.get("subject_procedures"):
-            from aind_data_schema.core.procedures import Procedures as ProceduresModel
+        # Validate to get Procedures object with parsed procedures
+        procedures_obj = Procedures.model_validate(base_procedures)
 
-            proc = base_procedures["subject_procedures"][0]
-            procedures_list_1 = [ProceduresModel.model_validate_json(json.dumps(proc))]
-            procedures_list_2 = [ProceduresModel.model_validate_json(json.dumps(proc))]
+        if procedures_obj.subject_procedures:
+            # Use same procedure in both lists to create a duplicate
+            proc = procedures_obj.subject_procedures[0]
+            procedures_list_1 = [proc]
+            procedures_list_2 = [proc]
 
             duplicates = self.job._find_duplicate_procedures(procedures_list_1, procedures_list_2)
             self.assertEqual(len(duplicates), 1)
@@ -1261,8 +1266,6 @@ class TestGatherMetadataJob(unittest.TestCase):
     @patch("os.makedirs")
     def test_merge_procedures_no_duplicates(self, mock_makedirs):
         """Test _merge_procedures with no duplicates merges successfully"""
-        import json
-
         with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
             base_procedures = json.load(f)
 
@@ -1283,8 +1286,6 @@ class TestGatherMetadataJob(unittest.TestCase):
     @patch("os.makedirs")
     def test_merge_procedures_with_duplicates_raises(self, mock_makedirs):
         """Test _merge_procedures with duplicates raises error when raise_if_invalid is True"""
-        import json
-
         strict_settings = JobSettings(
             metadata_dir="/test/metadata",
             output_dir="/test/output",
@@ -1312,8 +1313,6 @@ class TestGatherMetadataJob(unittest.TestCase):
     @patch("os.makedirs")
     def test_merge_procedures_with_duplicates_defaults_to_user(self, mock_makedirs):
         """Test _merge_procedures with duplicates defaults to user procedures when raise_if_invalid is False"""
-        import json
-
         lenient_settings = JobSettings(
             metadata_dir="/test/metadata",
             output_dir="/test/output",

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -7,8 +7,6 @@ Do not test run_job() inside this file, use the integration tests.
 
 import json
 import os
-import shutil
-import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,9 +14,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 from aind_data_schema.components.subjects import CalibrationObject
 from aind_data_schema.core.acquisition import Acquisition
-from aind_data_schema.core.instrument import Instrument
 from aind_data_schema.core.procedures import Procedures
-from aind_data_schema.core.quality_control import QualityControl
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -1172,6 +1172,173 @@ class TestGatherMetadataJob(unittest.TestCase):
             self.job.copy_original_metadata_files()
             mock_warning.assert_called_once_with("Failed to copy subject.json: Permission denied")
 
+    # Tests for procedures merging
+    @patch.object(GatherMetadataJob, "_does_file_exist_in_user_defined_dir")
+    @patch("aind_metadata_mapper.gather_metadata.get_procedures")
+    def test_get_procedures_from_service_only(self, mock_get_procedures, mock_file_exists):
+        """Test get_procedures when only service procedures are available"""
+        mock_file_exists.return_value = False
+        mock_get_procedures.return_value = {"subject_id": "123456", "subject_procedures": []}
+
+        result = self.job.get_procedures(subject_id="123456")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["subject_id"], "123456")
+        mock_get_procedures.assert_called_once_with("123456", base_url="http://test-service.com/api/v2/procedures/")
+
+    @patch.object(GatherMetadataJob, "_does_file_exist_in_user_defined_dir")
+    @patch.object(GatherMetadataJob, "_get_file_from_user_defined_directory")
+    @patch("aind_metadata_mapper.gather_metadata.get_procedures")
+    def test_get_procedures_from_user_only(self, mock_get_procedures, mock_get_file, mock_file_exists):
+        """Test get_procedures when only user procedures are available"""
+        mock_file_exists.return_value = True
+        mock_get_file.return_value = {"subject_id": "123456", "subject_procedures": []}
+        mock_get_procedures.return_value = None
+
+        result = self.job.get_procedures(subject_id="123456")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["subject_id"], "123456")
+        mock_file_exists.assert_called_once_with(file_name="procedures.json")
+
+    @patch.object(GatherMetadataJob, "_does_file_exist_in_user_defined_dir")
+    @patch.object(GatherMetadataJob, "_get_file_from_user_defined_directory")
+    @patch("aind_metadata_mapper.gather_metadata.get_procedures")
+    @patch.object(GatherMetadataJob, "_merge_procedures")
+    def test_get_procedures_merge_both_available(
+        self, mock_merge, mock_get_procedures, mock_get_file, mock_file_exists
+    ):
+        """Test get_procedures when both user and service procedures are available"""
+        mock_file_exists.return_value = True
+        user_procs = {"subject_id": "123456", "subject_procedures": []}
+        service_procs = {"subject_id": "123456", "subject_procedures": []}
+        mock_get_file.return_value = user_procs
+        mock_get_procedures.return_value = service_procs
+        mock_merge.return_value = user_procs
+
+        result = self.job.get_procedures(subject_id="123456")
+
+        self.assertIsNotNone(result)
+        mock_merge.assert_called_once_with(user_procs, service_procs)
+
+    def test_find_duplicate_procedures_no_duplicates(self):
+        """Test _find_duplicate_procedures when no duplicates exist"""
+        import json
+
+        with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
+            base_procedures = json.load(f)
+
+        # Create two different procedure lists
+        proc1 = base_procedures.get("subject_procedures", [])[0] if base_procedures.get("subject_procedures") else None
+        proc2 = base_procedures.get("subject_procedures", [])[1] if len(base_procedures.get("subject_procedures", [])) > 1 else None
+
+        if proc1 and proc2:
+            from aind_data_schema.core.procedures import Procedures as ProceduresModel
+
+            procedures_list_1 = [ProceduresModel.model_validate_json(json.dumps(proc1))]
+            procedures_list_2 = [ProceduresModel.model_validate_json(json.dumps(proc2))]
+
+            duplicates = self.job._find_duplicate_procedures(procedures_list_1, procedures_list_2)
+            self.assertEqual(len(duplicates), 0)
+
+    def test_find_duplicate_procedures_with_duplicates(self):
+        """Test _find_duplicate_procedures when duplicates exist"""
+        import json
+
+        with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
+            base_procedures = json.load(f)
+
+        if base_procedures.get("subject_procedures"):
+            from aind_data_schema.core.procedures import Procedures as ProceduresModel
+
+            proc = base_procedures["subject_procedures"][0]
+            procedures_list_1 = [ProceduresModel.model_validate_json(json.dumps(proc))]
+            procedures_list_2 = [ProceduresModel.model_validate_json(json.dumps(proc))]
+
+            duplicates = self.job._find_duplicate_procedures(procedures_list_1, procedures_list_2)
+            self.assertEqual(len(duplicates), 1)
+
+    @patch("os.makedirs")
+    def test_merge_procedures_no_duplicates(self, mock_makedirs):
+        """Test _merge_procedures with no duplicates merges successfully"""
+        import json
+
+        with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
+            base_procedures = json.load(f)
+
+        user_procedures = base_procedures.copy()
+        service_procedures = base_procedures.copy()
+
+        # Remove all procedures from service to avoid duplicates
+        if service_procedures.get("subject_procedures"):
+            service_procedures["subject_procedures"] = []
+        if service_procedures.get("specimen_procedures"):
+            service_procedures["specimen_procedures"] = []
+
+        result = self.job._merge_procedures(user_procedures, service_procedures)
+
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, dict)
+
+    @patch("os.makedirs")
+    def test_merge_procedures_with_duplicates_raises(self, mock_makedirs):
+        """Test _merge_procedures with duplicates raises error when raise_if_invalid is True"""
+        import json
+
+        strict_settings = JobSettings(
+            metadata_dir="/test/metadata",
+            output_dir="/test/output",
+            subject_id="123456",
+            data_description_settings=DataDescriptionSettings(
+                project_name="Test Project",
+                modalities=[Modality.ECEPHYS],
+            ),
+            acquisition_start_time=datetime(2023, 1, 1, 12, 0, 0),
+            raise_if_invalid=True,
+        )
+        strict_job = GatherMetadataJob(settings=strict_settings)
+
+        with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
+            base_procedures = json.load(f)
+
+        user_procedures = base_procedures.copy()
+        service_procedures = base_procedures.copy()
+
+        with self.assertRaises(ValueError) as context:
+            strict_job._merge_procedures(user_procedures, service_procedures)
+
+        self.assertIn("duplicate procedures", str(context.exception).lower())
+
+    @patch("os.makedirs")
+    def test_merge_procedures_with_duplicates_defaults_to_user(self, mock_makedirs):
+        """Test _merge_procedures with duplicates defaults to user procedures when raise_if_invalid is False"""
+        import json
+
+        lenient_settings = JobSettings(
+            metadata_dir="/test/metadata",
+            output_dir="/test/output",
+            subject_id="123456",
+            data_description_settings=DataDescriptionSettings(
+                project_name="Test Project",
+                modalities=[Modality.ECEPHYS],
+            ),
+            acquisition_start_time=datetime(2023, 1, 1, 12, 0, 0),
+            raise_if_invalid=False,
+        )
+        lenient_job = GatherMetadataJob(settings=lenient_settings)
+
+        with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
+            base_procedures = json.load(f)
+
+        user_procedures = base_procedures.copy()
+        service_procedures = base_procedures.copy()
+
+        with patch("logging.warning"):
+            result = lenient_job._merge_procedures(user_procedures, service_procedures)
+
+        # Should return user procedures
+        self.assertEqual(result, user_procedures)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -1331,10 +1331,8 @@ class TestGatherMetadataJob(unittest.TestCase):
         service_procedures = base_procedures.copy()
 
         # Remove all procedures from service to avoid duplicates
-        if service_procedures.get("subject_procedures"):
-            service_procedures["subject_procedures"] = []
-        if service_procedures.get("specimen_procedures"):
-            service_procedures["specimen_procedures"] = []
+        service_procedures["subject_procedures"] = []
+        service_procedures["specimen_procedures"] = []
 
         result = self.job._merge_procedures(user_procedures, service_procedures)
 

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -1296,19 +1296,15 @@ class TestGatherMetadataJob(unittest.TestCase):
         with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
             base_procedures = json.load(f)
 
-        # Validate to get Procedures object with parsed procedures
         procedures_obj = Procedures.model_validate(base_procedures)
+        # Always test with two different procedures
+        proc1 = procedures_obj.subject_procedures[0] if procedures_obj.subject_procedures else None
+        proc2 = procedures_obj.subject_procedures[1] if procedures_obj.subject_procedures and len(procedures_obj.subject_procedures) > 1 else None
 
-        if procedures_obj.subject_procedures and len(procedures_obj.subject_procedures) > 1:
-            # Use first two procedures as separate lists (no duplicates between them)
-            procedures_list_1 = [procedures_obj.subject_procedures[0]]
-            procedures_list_2 = [procedures_obj.subject_procedures[1]]
-        else:
-            # If only one procedure, use empty list for no duplicates
-            procedures_list_1 = procedures_obj.subject_procedures or []
-            procedures_list_2 = []
+        self.assertIsNotNone(proc1, "Test fixture must have at least one procedure")
+        self.assertIsNotNone(proc2, "Test fixture must have at least two procedures")
 
-        duplicates = self.job._find_duplicate_procedures(procedures_list_1, procedures_list_2)
+        duplicates = self.job._find_duplicate_procedures([proc1], [proc2])
         self.assertEqual(len(duplicates), 0)
 
     def test_find_duplicate_procedures_with_duplicates(self):
@@ -1316,17 +1312,13 @@ class TestGatherMetadataJob(unittest.TestCase):
         with open(TEST_DIR / "resources" / "v2_metadata" / "procedures.json") as f:
             base_procedures = json.load(f)
 
-        # Validate to get Procedures object with parsed procedures
         procedures_obj = Procedures.model_validate(base_procedures)
+        self.assertTrue(procedures_obj.subject_procedures, "Test fixture must have at least one procedure")
 
-        if procedures_obj.subject_procedures:
-            # Use same procedure in both lists to create a duplicate
-            proc = procedures_obj.subject_procedures[0]
-            procedures_list_1 = [proc]
-            procedures_list_2 = [proc]
-
-            duplicates = self.job._find_duplicate_procedures(procedures_list_1, procedures_list_2)
-            self.assertEqual(len(duplicates), 1)
+        # Use same procedure in both lists to create a duplicate
+        proc = procedures_obj.subject_procedures[0]
+        duplicates = self.job._find_duplicate_procedures([proc], [proc])
+        self.assertEqual(len(duplicates), 1)
 
     @patch("os.makedirs")
     def test_merge_procedures_no_duplicates(self, mock_makedirs):

--- a/tests/test_gather_metadata.py
+++ b/tests/test_gather_metadata.py
@@ -1297,12 +1297,13 @@ class TestGatherMetadataJob(unittest.TestCase):
             base_procedures = json.load(f)
 
         procedures_obj = Procedures.model_validate(base_procedures)
-        # Always test with two different procedures
-        proc1 = procedures_obj.subject_procedures[0] if procedures_obj.subject_procedures else None
-        proc2 = procedures_obj.subject_procedures[1] if procedures_obj.subject_procedures and len(procedures_obj.subject_procedures) > 1 else None
+        self.assertTrue(procedures_obj.subject_procedures, "Test fixture must have at least one procedure")
 
-        self.assertIsNotNone(proc1, "Test fixture must have at least one procedure")
-        self.assertIsNotNone(proc2, "Test fixture must have at least two procedures")
+        proc1 = procedures_obj.subject_procedures[0]
+        # Create a second different procedure by copying and modifying the first
+        proc2_dict = json.loads(proc1.model_dump_json())
+        proc2_dict["start_date"] = "2025-07-11"  # Make it different from proc1
+        proc2 = type(proc1).model_validate(proc2_dict)
 
         duplicates = self.job._find_duplicate_procedures([proc1], [proc2])
         self.assertEqual(len(duplicates), 0)


### PR DESCRIPTION
This PR adds support for merging user-provided procedures.json files with the metadata service. The logic proceeds as follows:

1. Attempt to load both the user and metadata-service procedures
2. If only one is present, use that
3. If both are present, check for duplicates
4. If duplicate procedures show up raise an error (if raise_if_invalid) or throw a warning. Then ONLY use the user provided json (under the assumption that the user already merged)