### PR TITLE
Add iacuc function to utils

### DIFF
--- a/src/aind_metadata_mapper/utils.py
+++ b/src/aind_metadata_mapper/utils.py
@@ -178,10 +178,10 @@ def get_iacuc_protocol(subject_id: str | int, base_url: str = LABTRACKS_SUBJECT_
     """Fetch a subject's current IACUC protocol number from LabTracks.
 
     LabTracks is the regulatory source of truth for which protocol a mouse is on. The
-    metadata service exposes the LabTracks subject record, whose current group name encodes
-    the protocol as its trailing dash-delimited number (e.g. "Exp-ND-01-001-2414" -> "2414").
-    A trailing site tag such as " AIND" is dropped, and groups with no protocol number (e.g.
-    "Practice Mice") or subjects not in LabTracks yield None.
+    metadata service exposes the LabTracks subject record, which includes a
+    ``protocol_number`` field joined directly from the LabTracks ``IacucProtocol`` table
+    (e.g. "2414"). This is more reliable than parsing the group name, which does not
+    consistently encode the protocol (e.g. breeding mice have genotype-based group names).
 
     Note that, in the future, this information will also be tracked in DataVerse.
     This function could be updated to pull from there in the future if desired.
@@ -196,8 +196,8 @@ def get_iacuc_protocol(subject_id: str | int, base_url: str = LABTRACKS_SUBJECT_
     Returns
     -------
     Optional[str]
-        The bare IACUC protocol number (e.g. "2414"), or None if the subject is not in
-        LabTracks, its group carries no protocol number, or the request fails.
+        The IACUC protocol number (e.g. "2414"), or None if the subject is not in
+        LabTracks, has no associated protocol, or the request fails.
     """
     try:
         subject_id = str(subject_id)
@@ -208,12 +208,8 @@ def get_iacuc_protocol(subject_id: str | int, base_url: str = LABTRACKS_SUBJECT_
             logger.warning(f"Could not fetch LabTracks subject {subject_id}")
             return None
         records = records if isinstance(records, list) else [records]
-        group_name = records[0].get("group_name") or ""
-        # Protocol is the last dash-delimited chunk; drop any trailing site tag and keep
-        # it only if it is numeric (so "Practice Mice" and the like yield None).
-        tokens = group_name.split("-")[-1].split()
-        protocol = tokens[0] if tokens else ""
-        return protocol if protocol.isdigit() else None
+        protocol_number = records[0].get("protocol_number")
+        return str(protocol_number) if protocol_number else None
     except Exception as e:
         logger.warning(f"Unexpected error fetching IACUC protocol for subject {subject_id}: {e}")
         return None

--- a/src/aind_metadata_mapper/utils.py
+++ b/src/aind_metadata_mapper/utils.py
@@ -183,6 +183,9 @@ def get_iacuc_protocol(subject_id: str, base_url: str = LABTRACKS_SUBJECT_BASE_U
     A trailing site tag such as " AIND" is dropped, and groups with no protocol number (e.g.
     "Practice Mice") or subjects not in LabTracks yield None.
 
+    Note that, in the future, this information will also be tracked in DataVerse.
+    This function could be updated to pull from there in the future if desired.
+
     Parameters
     ----------
     subject_id : str

--- a/src/aind_metadata_mapper/utils.py
+++ b/src/aind_metadata_mapper/utils.py
@@ -179,9 +179,8 @@ def get_iacuc_protocol(subject_id: str | int, base_url: str = LABTRACKS_SUBJECT_
 
     LabTracks is the regulatory source of truth for which protocol a mouse is on. The
     metadata service exposes the LabTracks subject record, which includes a
-    ``protocol_number`` field joined directly from the LabTracks ``IacucProtocol`` table
-    (e.g. "2414"). This is more reliable than parsing the group name, which does not
-    consistently encode the protocol (e.g. breeding mice have genotype-based group names).
+    ``protocol_number`` field (e.g. "2414") joined directly from the LabTracks
+    ``IacucProtocol`` table.
 
     Note that, in the future, this information will also be tracked in DataVerse.
     This function could be updated to pull from there in the future if desired.

--- a/src/aind_metadata_mapper/utils.py
+++ b/src/aind_metadata_mapper/utils.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 INSTRUMENT_BASE_URL = "http://aind-metadata-service/api/v2/instrument"
 PROCEDURES_BASE_URL = "http://aind-metadata-service/api/v2/procedures"
 SUBJECT_BASE_URL = "http://aind-metadata-service/api/v2/subject"
+LABTRACKS_SUBJECT_BASE_URL = "http://aind-metadata-service/api/v2/labtracks/subject"
 
 
 def normalize_utc_timezone(dt: str) -> str:
@@ -170,6 +171,47 @@ def get_procedures(subject_id: str, base_url: str = PROCEDURES_BASE_URL, timeout
         return result
     except Exception as e:
         logger.warning(f"Unexpected error fetching procedures for subject {subject_id}: {e}")
+        return None
+
+
+def get_iacuc_protocol(subject_id: str, base_url: str = LABTRACKS_SUBJECT_BASE_URL) -> Optional[str]:
+    """Fetch a subject's current IACUC protocol number from LabTracks.
+
+    LabTracks is the regulatory source of truth for which protocol a mouse is on. The
+    metadata service exposes the LabTracks subject record, whose current group name encodes
+    the protocol as its trailing dash-delimited number (e.g. "Exp-ND-01-001-2414" -> "2414").
+    A trailing site tag such as " AIND" is dropped, and groups with no protocol number (e.g.
+    "Practice Mice") or subjects not in LabTracks yield None.
+
+    Parameters
+    ----------
+    subject_id : str
+        The subject ID to query.
+    base_url : str
+        Base URL for the LabTracks subject endpoint. Defaults to LABTRACKS_SUBJECT_BASE_URL.
+
+    Returns
+    -------
+    Optional[str]
+        The bare IACUC protocol number (e.g. "2414"), or None if the subject is not in
+        LabTracks, its group carries no protocol number, or the request fails.
+    """
+    try:
+        # This endpoint takes subject_id as a query parameter, not a path segment.
+        url = f"{base_url}?subject_id={subject_id}"
+        records = metadata_service_helper(url)
+        if not records:
+            logger.warning(f"Could not fetch LabTracks subject {subject_id}")
+            return None
+        records = records if isinstance(records, list) else [records]
+        group_name = records[0].get("group_name") or ""
+        # Protocol is the last dash-delimited chunk; drop any trailing site tag and keep
+        # it only if it is numeric (so "Practice Mice" and the like yield None).
+        tokens = group_name.split("-")[-1].split()
+        protocol = tokens[0] if tokens else ""
+        return protocol if protocol.isdigit() else None
+    except Exception as e:
+        logger.warning(f"Unexpected error fetching IACUC protocol for subject {subject_id}: {e}")
         return None
 
 

--- a/src/aind_metadata_mapper/utils.py
+++ b/src/aind_metadata_mapper/utils.py
@@ -174,7 +174,7 @@ def get_procedures(subject_id: str, base_url: str = PROCEDURES_BASE_URL, timeout
         return None
 
 
-def get_iacuc_protocol(subject_id: str, base_url: str = LABTRACKS_SUBJECT_BASE_URL) -> Optional[str]:
+def get_iacuc_protocol(subject_id: str | int, base_url: str = LABTRACKS_SUBJECT_BASE_URL) -> Optional[str]:
     """Fetch a subject's current IACUC protocol number from LabTracks.
 
     LabTracks is the regulatory source of truth for which protocol a mouse is on. The
@@ -188,8 +188,8 @@ def get_iacuc_protocol(subject_id: str, base_url: str = LABTRACKS_SUBJECT_BASE_U
 
     Parameters
     ----------
-    subject_id : str
-        The subject ID to query.
+    subject_id : str or int
+        The subject ID to query. An int is cast to str automatically.
     base_url : str
         Base URL for the LabTracks subject endpoint. Defaults to LABTRACKS_SUBJECT_BASE_URL.
 
@@ -200,6 +200,7 @@ def get_iacuc_protocol(subject_id: str, base_url: str = LABTRACKS_SUBJECT_BASE_U
         LabTracks, its group carries no protocol number, or the request fails.
     """
     try:
+        subject_id = str(subject_id)
         # This endpoint takes subject_id as a query parameter, not a path segment.
         url = f"{base_url}?subject_id={subject_id}"
         records = metadata_service_helper(url)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -650,6 +650,12 @@ class TestGetIacucProtocol(unittest.TestCase):
         self.assertEqual(get_iacuc_protocol("818908"), "2414")
 
     @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_accepts_int_subject_id(self, mock_helper):
+        """An int subject_id is cast to str and handled."""
+        mock_helper.return_value = [{"group_name": "Exp-ND-01-001-2414"}]
+        self.assertEqual(get_iacuc_protocol(818908), "2414")
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
     def test_drops_trailing_site_tag(self, mock_helper):
         """A trailing site tag (e.g. ' AIND') is ignored."""
         mock_helper.return_value = [{"group_name": "Exp-ND-01-020-2414 AIND"}]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -644,32 +644,38 @@ class TestGetIacucProtocol(unittest.TestCase):
     """Tests for get_iacuc_protocol function."""
 
     @patch("aind_metadata_mapper.utils.metadata_service_helper")
-    def test_returns_protocol_from_group_name(self, mock_helper):
-        """Trailing dash-delimited number of the group name is returned."""
-        mock_helper.return_value = [{"group_name": "Exp-ND-01-001-2414"}]
+    def test_returns_protocol_number_field(self, mock_helper):
+        """The protocol_number field (joined from the IacucProtocol table) is returned."""
+        mock_helper.return_value = [{"group_name": "Exp-ND-01-001-2414", "protocol_number": "2414"}]
         self.assertEqual(get_iacuc_protocol("818908"), "2414")
 
     @patch("aind_metadata_mapper.utils.metadata_service_helper")
     def test_accepts_int_subject_id(self, mock_helper):
         """An int subject_id is cast to str and handled."""
-        mock_helper.return_value = [{"group_name": "Exp-ND-01-001-2414"}]
+        mock_helper.return_value = [{"protocol_number": "2414"}]
         self.assertEqual(get_iacuc_protocol(818908), "2414")
 
     @patch("aind_metadata_mapper.utils.metadata_service_helper")
-    def test_drops_trailing_site_tag(self, mock_helper):
-        """A trailing site tag (e.g. ' AIND') is ignored."""
-        mock_helper.return_value = [{"group_name": "Exp-ND-01-020-2414 AIND"}]
+    def test_returns_protocol_when_group_name_lacks_number(self, mock_helper):
+        """A breeding-group name with no trailing number still resolves via protocol_number."""
+        mock_helper.return_value = [{"group_name": "Pdyn-IRES-Cre;Oi9(ND)", "protocol_number": "2453"}]
+        self.assertEqual(get_iacuc_protocol("x"), "2453")
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_numeric_protocol_number_is_coerced_to_str(self, mock_helper):
+        """A non-string protocol_number is coerced to str."""
+        mock_helper.return_value = [{"protocol_number": 2414}]
         self.assertEqual(get_iacuc_protocol("x"), "2414")
 
     @patch("aind_metadata_mapper.utils.metadata_service_helper")
-    def test_non_numeric_group_returns_none(self, mock_helper):
-        """A group with no protocol number (e.g. 'Practice Mice') yields None."""
-        mock_helper.return_value = [{"group_name": "Practice Mice"}]
+    def test_null_protocol_number_returns_none(self, mock_helper):
+        """A record with a null protocol_number yields None."""
+        mock_helper.return_value = [{"group_name": "Practice Mice", "protocol_number": None}]
         self.assertIsNone(get_iacuc_protocol("x"))
 
     @patch("aind_metadata_mapper.utils.metadata_service_helper")
-    def test_missing_group_name_returns_none(self, mock_helper):
-        """A record without a group_name yields None."""
+    def test_missing_protocol_number_returns_none(self, mock_helper):
+        """A record without a protocol_number yields None."""
         mock_helper.return_value = [{}]
         self.assertIsNone(get_iacuc_protocol("x"))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -686,8 +686,8 @@ class TestGetIacucProtocol(unittest.TestCase):
         self.assertIsNone(get_iacuc_protocol("x"))
 
     @patch("aind_metadata_mapper.utils.metadata_service_helper")
-    def test_dict_response_is_normalized(self, mock_helper):
-        """A non-list (dict) response is normalized and handled gracefully."""
+    def test_dict_error_body_returns_none(self, mock_helper):
+        """A non-list error body (e.g. {"detail": "Not Found"}) yields None."""
         mock_helper.return_value = {"detail": "Not Found"}
         self.assertIsNone(get_iacuc_protocol("x"))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,7 @@ from aind_metadata_mapper.utils import (
     check_existing_instrument,
     check_instrument_id,
     ensure_timezone,
+    get_iacuc_protocol,
     get_instrument,
     get_intended_measurements,
     get_procedures,
@@ -637,6 +638,52 @@ class TestPromptFunctions(unittest.TestCase):
             prompt_for_string("Test", required=True, help_message="Help", input_func=input_func)
         self.assertEqual(call_count[0], 2)
         self.assertTrue(any("Help" in str(call) for call in mock_print.call_args_list))
+
+
+class TestGetIacucProtocol(unittest.TestCase):
+    """Tests for get_iacuc_protocol function."""
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_returns_protocol_from_group_name(self, mock_helper):
+        """Trailing dash-delimited number of the group name is returned."""
+        mock_helper.return_value = [{"group_name": "Exp-ND-01-001-2414"}]
+        self.assertEqual(get_iacuc_protocol("818908"), "2414")
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_drops_trailing_site_tag(self, mock_helper):
+        """A trailing site tag (e.g. ' AIND') is ignored."""
+        mock_helper.return_value = [{"group_name": "Exp-ND-01-020-2414 AIND"}]
+        self.assertEqual(get_iacuc_protocol("x"), "2414")
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_non_numeric_group_returns_none(self, mock_helper):
+        """A group with no protocol number (e.g. 'Practice Mice') yields None."""
+        mock_helper.return_value = [{"group_name": "Practice Mice"}]
+        self.assertIsNone(get_iacuc_protocol("x"))
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_missing_group_name_returns_none(self, mock_helper):
+        """A record without a group_name yields None."""
+        mock_helper.return_value = [{}]
+        self.assertIsNone(get_iacuc_protocol("x"))
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_no_records_returns_none(self, mock_helper):
+        """No records (helper returns None) yields None."""
+        mock_helper.return_value = None
+        self.assertIsNone(get_iacuc_protocol("x"))
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_dict_response_is_normalized(self, mock_helper):
+        """A non-list (dict) response is normalized and handled gracefully."""
+        mock_helper.return_value = {"detail": "Not Found"}
+        self.assertIsNone(get_iacuc_protocol("x"))
+
+    @patch("aind_metadata_mapper.utils.metadata_service_helper")
+    def test_exception_returns_none(self, mock_helper):
+        """An unexpected error is caught and yields None."""
+        mock_helper.side_effect = ValueError("boom")
+        self.assertIsNone(get_iacuc_protocol("x"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a function to utils to allow us to pull the iacuc protocol for a given mouse.

Claude Code discovered for me that the trailing portion of the "Group name" field returned by the the labtracks subject endpoint in the metadata service encodes the IACUC protocol. It's not clear to my why it's encoded this way, but I verified that for over 700 mice the protocol returned by this method matches the protocol in the procedures metadata. There were only an handful of exceptions and these seem to be due to the mouse having been transferred to a different protocol after the procedure was performed. So this method seems reliable for giving us the current iacuc protocol.

Use would be:

```
from aind-metadata-mapper.utils import get_iacuc_protocol
protocol_id = get_iacuc_protocol(subject_id=818908)
print(protocol_id)
```
Which would return `2414` for this subject.

Confirming:
<img width="453" height="44" alt="image" src="https://github.com/user-attachments/assets/98777f71-a8b1-4570-8236-437a2a867ba0" />

This should be a step toward resolving these two issues:
https://github.com/AllenNeuralDynamics/aind-metadata-mapper/issues/415
https://github.com/AllenNeuralDynamics/aind-metadata-mapper/issues/431