### PR TITLE
feat: option to add diff institution in data description

### DIFF
--- a/src/aind_metadata_mapper/gather_metadata.py
+++ b/src/aind_metadata_mapper/gather_metadata.py
@@ -21,7 +21,6 @@ from aind_data_schema.core.processing import Processing
 from aind_data_schema.core.quality_control import QualityControl
 from aind_data_schema.core.subject import Subject
 from aind_data_schema_models.data_name_patterns import DataLevel
-from aind_data_schema_models.organizations import Organization
 from pydantic import ValidationError
 
 from aind_metadata_mapper.base import MapperJobSettings
@@ -212,7 +211,7 @@ class GatherMetadataJob:
         # Create new data description
         new_data_description = DataDescription(
             creation_time=creation_time,
-            institution=Organization.AIND,
+            institution=self.settings.data_description_settings.institution,
             project_name=self.settings.data_description_settings.project_name,
             modalities=modalities,
             funding_source=funding_source,

--- a/src/aind_metadata_mapper/models.py
+++ b/src/aind_metadata_mapper/models.py
@@ -6,6 +6,7 @@ from aind_data_schema.base import AwareDatetimeWithDefault
 from aind_data_schema.components.subjects import CalibrationObject
 from aind_data_schema_models.data_name_patterns import Group
 from aind_data_schema_models.modalities import Modality
+from aind_data_schema_models.organizations import Organization
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
@@ -36,6 +37,9 @@ class DataDescriptionSettings(BaseSettings):
     data_summary: Optional[str] = Field(
         default=None,
         description="Semantic summary of experimental goal.",
+    )
+    institution: Organization.ONE_OF = Field(
+        default=Organization.AIND, description="Research organization that collected the data."
     )
 
     @field_validator("modalities", mode="before")


### PR DESCRIPTION
Closes #486 

- Allows user to set the institution that they want when creating a data_description
- Default is Organization.AIND to keep backwards compatibility 